### PR TITLE
Initial Additional Sign Up Screen

### DIFF
--- a/Utah.xcodeproj/project.pbxproj
+++ b/Utah.xcodeproj/project.pbxproj
@@ -216,6 +216,7 @@
 				653A2549283387FE005D4D48 /* Sources */,
 				653A254A283387FE005D4D48 /* Frameworks */,
 				653A254B283387FE005D4D48 /* Resources */,
+				23B044A4299DFBE1008CD957 /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -360,6 +361,27 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		23B044A4299DFBE1008CD957 /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint > /dev/null; then\n  swiftlint --fix && swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		653A2549283387FE005D4D48 /* Sources */ = {

--- a/UtahModules/Sources/UtahOnboardingFlow/AccountSetup/AccountSetup.swift
+++ b/UtahModules/Sources/UtahOnboardingFlow/AccountSetup/AccountSetup.swift
@@ -8,7 +8,9 @@
 
 import Account
 import class FHIR.FHIR
+import Firebase
 import FirebaseAccount
+import FirebaseFirestore
 import Onboarding
 import SwiftUI
 
@@ -35,22 +37,25 @@ struct AccountSetup: View {
                 actionView
             }
         )
-            .onReceive(account.objectWillChange) {
-                if account.signedIn {
-                    onboardingSteps.append(.healthKitPermissions)
-                    // Unfortunately, SwiftUI currently animates changes in the navigation path that do not change
-                    // the current top view. Therefore we need to do the following async procedure to remove the
-                    // `.login` and `.signUp` steps while disabling the animations before and re-enabling them
-                    // after the elements have been changed.
-                    Task { @MainActor in
-                        try? await Task.sleep(for: .seconds(1.0))
-                        UIView.setAnimationsEnabled(false)
-                        onboardingSteps.removeAll(where: { $0 == .login || $0 == .signUp })
-                        try? await Task.sleep(for: .seconds(1.0))
-                        UIView.setAnimationsEnabled(true)
-                    }
+        .onReceive(account.objectWillChange) {
+            if account.signedIn {
+                if onboardingSteps.contains(where: { $0 == .signUp }) {
+                    onboardingSteps.append(.userInfo)
                 }
             }
+             onboardingSteps.append(.healthKitPermissions)
+            // Unfortunately, SwiftUI currently animates changes in the navigation path that do not change
+            // the current top view. Therefore we need to do the following async procedure to remove the
+            // `.login` and `.signUp` steps while disabling the animations before and re-enabling them
+            // after the elements have been changed.
+            Task { @MainActor in
+                try? await Task.sleep(for: .seconds(1.0))
+                UIView.setAnimationsEnabled(false)
+                onboardingSteps.removeAll(where: { $0 == .login || $0 == .signUp })
+                try? await Task.sleep(for: .seconds(1.0))
+                UIView.setAnimationsEnabled(true)
+            }
+        }
     }
     
     @ViewBuilder

--- a/UtahModules/Sources/UtahOnboardingFlow/AccountSetup/AccountSetup.swift
+++ b/UtahModules/Sources/UtahOnboardingFlow/AccountSetup/AccountSetup.swift
@@ -39,21 +39,18 @@ struct AccountSetup: View {
         )
         .onReceive(account.objectWillChange) {
             if account.signedIn {
-                if onboardingSteps.contains(where: { $0 == .signUp }) {
-                    onboardingSteps.append(.userInfo)
+                onboardingSteps.append(.healthKitPermissions)
+                // Unfortunately, SwiftUI currently animates changes in the navigation path that do not change
+                // the current top view. Therefore we need to do the following async procedure to remove the
+                // `.login` and `.signUp` steps while disabling the animations before and re-enabling them
+                // after the elements have been changed.
+                Task { @MainActor in
+                    try? await Task.sleep(for: .seconds(1.0))
+                    UIView.setAnimationsEnabled(false)
+                    onboardingSteps.removeAll(where: { $0 == .login || $0 == .signUp })
+                    try? await Task.sleep(for: .seconds(1.0))
+                    UIView.setAnimationsEnabled(true)
                 }
-            }
-             onboardingSteps.append(.healthKitPermissions)
-            // Unfortunately, SwiftUI currently animates changes in the navigation path that do not change
-            // the current top view. Therefore we need to do the following async procedure to remove the
-            // `.login` and `.signUp` steps while disabling the animations before and re-enabling them
-            // after the elements have been changed.
-            Task { @MainActor in
-                try? await Task.sleep(for: .seconds(1.0))
-                UIView.setAnimationsEnabled(false)
-                onboardingSteps.removeAll(where: { $0 == .login || $0 == .signUp })
-                try? await Task.sleep(for: .seconds(1.0))
-                UIView.setAnimationsEnabled(true)
             }
         }
     }

--- a/UtahModules/Sources/UtahOnboardingFlow/AccountSetup/UserInfoSignUp.swift
+++ b/UtahModules/Sources/UtahOnboardingFlow/AccountSetup/UserInfoSignUp.swift
@@ -41,7 +41,7 @@ struct UserInfoSignUp: View {
                     Button(action: {
                         isEditing = false
                     }) {
-                        Text("Save")
+                        Text("Next")
                             .frame(maxWidth: .infinity, minHeight: 38)
                     }
                     .padding(.horizontal, 36)

--- a/UtahModules/Sources/UtahOnboardingFlow/AccountSetup/UserInfoSignUp.swift
+++ b/UtahModules/Sources/UtahOnboardingFlow/AccountSetup/UserInfoSignUp.swift
@@ -5,6 +5,8 @@
 //
 // SPDX-License-Identifier: MIT
 //
+import Firebase
+import FirebaseFirestore
 import SwiftUI
 
 struct UserInfoSignUp: View {
@@ -22,12 +24,9 @@ struct UserInfoSignUp: View {
                     Form {
                         Section(header: Text("Name")) {
                             TextField("First Name", text: $firstName)
-                                .font(.subheadline)
-                                .padding(.vertical, 10)
                             TextField("Last Name", text: $lastName)
-                                .font(.subheadline)
-                                .padding(.vertical, 10)
                         }
+                        .font(.subheadline)
                         .padding(.vertical, 10)
                         Section(header: Text("Disease")) {
                             Picker("Select your Disease", selection: $disease) {
@@ -39,7 +38,10 @@ struct UserInfoSignUp: View {
                         }
                     }
                     Button(action: {
-                        isEditing = false
+                        if let user = Auth.auth().currentUser {
+                            let data: [String: String] = ["firstName": firstName, "lastName": lastName, "disease": disease, "email": user.email ?? ""]
+                            Firestore.firestore().collection("users").document(user.uid).setData(data)
+                        }
                     }) {
                         Text("Next")
                             .frame(maxWidth: .infinity, minHeight: 38)

--- a/UtahModules/Sources/UtahOnboardingFlow/AccountSetup/UserInfoSignUp.swift
+++ b/UtahModules/Sources/UtahOnboardingFlow/AccountSetup/UserInfoSignUp.swift
@@ -1,0 +1,61 @@
+//
+// This source file is part of the CS342 2023 Utah Team Application project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+import SwiftUI
+
+struct UserInfoSignUp: View {
+    @State private var firstName = "First Name"
+    @State private var lastName = "Last Name"
+    @State private var disease = "I Don't Know"
+    @State private var isEditing = false
+    let diseaseOptions = ["Peripheral Arterial Disease", "Venous Insufficiency", "I Don't Know"]
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                Color(.systemGroupedBackground).ignoresSafeArea()
+                VStack {
+                    Form {
+                        Section(header: Text("Name")) {
+                            TextField("First Name", text: $firstName)
+                                .font(.subheadline)
+                                .padding(.vertical, 10)
+                            TextField("Last Name", text: $lastName)
+                                .font(.subheadline)
+                                .padding(.vertical, 10)
+                        }
+                        .padding(.vertical, 10)
+                        Section(header: Text("Disease")) {
+                            Picker("Select your Disease", selection: $disease) {
+                                ForEach(diseaseOptions, id: \.self) { option in
+                                    Text(option)
+                                }
+                            }
+                            .padding(.vertical, 10)
+                        }
+                    }
+                    Button(action: {
+                        isEditing = false
+                    }) {
+                        Text("Save")
+                            .frame(maxWidth: .infinity, minHeight: 38)
+                    }
+                    .padding(.horizontal, 36)
+                    .padding(.bottom, 16)
+                    .buttonStyle(.borderedProminent)
+                    .navigationTitle("More Information")
+                }
+            }
+        }
+    }
+}
+
+struct UserInformationView_Previews: PreviewProvider {
+    static var previews: some View {
+        UserInfoSignUp()
+    }
+}

--- a/UtahModules/Sources/UtahOnboardingFlow/AccountSetup/UserInfoSignUp.swift
+++ b/UtahModules/Sources/UtahOnboardingFlow/AccountSetup/UserInfoSignUp.swift
@@ -5,59 +5,113 @@
 //
 // SPDX-License-Identifier: MIT
 //
+import Account
+import CardinalKit
 import Firebase
 import FirebaseFirestore
+import Onboarding
 import SwiftUI
+import UtahSharedContext
 
 struct UserInfoSignUp: View {
-    @State private var firstName = "First Name"
-    @State private var lastName = "Last Name"
+    @State private var email = ""
+    @State private var password = ""
+    @State private var firstName = ""
+    @State private var lastName = ""
     @State private var disease = "I Don't Know"
     @State private var isEditing = false
     let diseaseOptions = ["Peripheral Arterial Disease", "Venous Insufficiency", "I Don't Know"]
+    
+    @State private var usernamePasswordValid = false
 
     var body: some View {
-        NavigationStack {
-            ZStack {
-                Color(.systemGroupedBackground).ignoresSafeArea()
-                VStack {
-                    Form {
-                        Section(header: Text("Name")) {
-                            TextField("First Name", text: $firstName)
-                            TextField("Last Name", text: $lastName)
-                        }
-                        .font(.subheadline)
-                        .padding(.vertical, 10)
-                        Section(header: Text("Disease")) {
-                            Picker("Select your Disease", selection: $disease) {
-                                ForEach(diseaseOptions, id: \.self) { option in
-                                    Text(option)
-                                }
-                            }
-                            .padding(.vertical, 10)
-                        }
-                    }
-                    Button(action: {
-                        if let user = Auth.auth().currentUser {
-                            let data: [String: String] = ["firstName": firstName, "lastName": lastName, "disease": disease, "email": user.email ?? ""]
-                            Firestore.firestore().collection("users").document(user.uid).setData(data)
-                        }
-                    }) {
-                        Text("Next")
-                            .frame(maxWidth: .infinity, minHeight: 38)
-                    }
-                    .padding(.horizontal, 36)
-                    .padding(.bottom, 16)
-                    .buttonStyle(.borderedProminent)
-                    .navigationTitle("More Information")
+        ZStack {
+            Color(.systemGroupedBackground).ignoresSafeArea()
+            VStack {
+                Form {
+                    usernamePasswordSection
+                    nameSection
+                    diseaseSection
+                }
+                button
+            }.navigationTitle("Sign Up")
+        }
+    }
+    
+    @ViewBuilder
+    private var usernamePasswordSection: some View {
+        Section(header: Text("Account")) {
+            Grid(horizontalSpacing: 12, verticalSpacing: 12) {
+                UsernamePasswordFields(
+                    username: $email,
+                    password: $password,
+                    valid: $usernamePasswordValid
+                )
+            }
+        }.padding(.vertical, 4)
+    }
+    
+    @ViewBuilder
+    private var button: some View {
+        Button(action: {
+            /* WILL DO IN NEXT COMMIT
+             if let user = Auth.auth().currentUser {
+                let data: [String: String] = ["firstName": firstName, "lastName": lastName, "disease": disease, "email": user.email ?? ""]
+                Firestore.firestore().collection("users").document(user.uid).setData(data)
+            }*/
+        }) {
+            Text("Next")
+                .frame(maxWidth: .infinity, minHeight: 38)
+        }
+        .padding(.horizontal, 36)
+        .padding(.bottom, 16)
+        .buttonStyle(.borderedProminent)
+    }
+    
+    @ViewBuilder
+    private var nameSection: some View {
+        Section(header: Text("Name")) {
+            Grid(horizontalSpacing: 12, verticalSpacing: 12) {
+                GridRow {
+                    Text("First Name")
+                        .fontWeight(.semibold)
+                        .gridColumnAlignment(.leading)
+                        .fixedSize(horizontal: false, vertical: true)
+                    TextField("First Name", text: $firstName)
+                        .frame(maxWidth: .infinity)
+                        .autocorrectionDisabled(true)
+                }
+                Divider()
+                GridRow {
+                    Text("Last Name")
+                        .fontWeight(.semibold)
+                        .gridColumnAlignment(.leading)
+                        .fixedSize(horizontal: false, vertical: true)
+                    TextField("Last Name", text: $lastName)
+                        .frame(maxWidth: .infinity)
+                        .autocorrectionDisabled(true)
                 }
             }
-        }
+        }.padding(.vertical, 4)
+    }
+    
+    @ViewBuilder
+    private var diseaseSection: some View {
+        Section(header: Text("Disease")) {
+            Grid(horizontalSpacing: 12, verticalSpacing: 12) {
+                Picker("Select your Disease", selection: $disease) {
+                    ForEach(diseaseOptions, id: \.self) { option in
+                        Text(option)
+                    }
+                }.fontWeight(.semibold)
+            }
+        }.padding(.vertical, 1)
     }
 }
 
 struct UserInformationView_Previews: PreviewProvider {
     static var previews: some View {
         UserInfoSignUp()
+            .environmentObject(Account(accountServices: []))
     }
 }

--- a/UtahModules/Sources/UtahOnboardingFlow/AccountSetup/UsernamePasswordFields.swift
+++ b/UtahModules/Sources/UtahOnboardingFlow/AccountSetup/UsernamePasswordFields.swift
@@ -1,0 +1,194 @@
+//
+// This source file is part of the CardinalKit open-source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+import Views
+
+
+struct UsernamePasswordFields: View {
+    @Binding private var valid: Bool
+    @Binding private var username: String
+    @Binding private var password: String
+    
+    @State private var passwordRepeat: String = ""
+    
+    @State private var usernameValid = false
+    @State private var passwordValid = false
+    @State private var passwordRepeatValid = false
+    
+    private var emailValidationRule: ValidationRule {
+        guard let regex = try? Regex("[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}") else {
+            fatalError("Invalid E-Mail Regex in the EmailPasswordAccountService")
+        }
+        
+        return ValidationRule(
+            regex: regex,
+            message: String(localized: "EAP_EMAIL_VERIFICATION_ERROR", bundle: .module)
+        )
+    }
+    
+    var body: some View {
+        Group {
+            usernameTextField
+            Divider()
+            passwordSecureField
+            Divider()
+            passwordRepeatSecureField
+        }
+            .onChange(of: usernameValid) { _ in
+                updateValid()
+            }
+            .onChange(of: passwordValid) { _ in
+                updateValid()
+            }
+            .onChange(of: passwordRepeatValid) { _ in
+                updateValid()
+            }
+            .onChange(of: password) { _ in
+                updateValid()
+            }
+            .onChange(of: passwordRepeat) { _ in
+                updateValid()
+            }
+    }
+    
+    private var usernameTextField: some View {
+        VerifiableTextRow(
+            text: $username,
+            valid: $usernameValid,
+            validationRules: [emailValidationRule],
+            description: {
+                Text("Email")
+            },
+            textField: { binding in
+                TextField(text: binding) {
+                    Text("Email")
+                }
+                    .autocorrectionDisabled(true)
+                    .textInputAutocapitalization(.never)
+                    .keyboardType(.emailAddress)
+                    .textContentType(.username)
+            }
+        )
+    }
+    
+    private var passwordSecureField: some View {
+        VerifiableTextRow(
+            text: $password,
+            valid: $passwordValid,
+            validationRules: [],
+            description: {
+                Text("Password")
+            },
+            textField: { binding in
+                SecureField(text: binding) {
+                    Text("Password")
+                }
+                    .autocorrectionDisabled(true)
+                    .textInputAutocapitalization(.never)
+                    .textContentType(.newPassword)
+            }
+        )
+    }
+    
+    private var passwordRepeatSecureField: some View {
+        VerifiableTextRow(
+            text: $passwordRepeat,
+            valid: $passwordRepeatValid,
+            validationRules: [],
+            description: {
+                Text("Password Verification")
+            },
+            textField: { binding in
+                VStack {
+                    SecureField(text: binding) {
+                        Text("Password")
+                    }
+                        .autocorrectionDisabled(true)
+                        .textInputAutocapitalization(.never)
+                        .textContentType(.newPassword)
+                    if password != passwordRepeat && !passwordRepeat.isEmpty {
+                        HStack {
+                            Text("Passwords Not Equal")
+                                .fixedSize(horizontal: false, vertical: true)
+                                .gridColumnAlignment(.leading)
+                                .font(.footnote)
+                                .foregroundColor(.red)
+                            Spacer(minLength: 0)
+                        }
+                    }
+                }
+            }
+        )
+    }
+    
+    
+    init(
+        username: Binding<String>,
+        password: Binding<String>,
+        valid: Binding<Bool>
+    ) {
+        self._username = username
+        self._password = password
+        self._valid = valid
+    }
+    
+    
+    private func updateValid() {
+        valid = usernameValid
+            && passwordValid
+            && passwordRepeatValid
+            && password == passwordRepeat
+    }
+}
+
+
+#if DEBUG
+struct UsernamePasswordFields_Previews: PreviewProvider {
+    @State private static var username: String = ""
+    @State private static var password: String = ""
+    @State private static var valid = false
+    
+    
+    private static var validationRules: [ValidationRule] {
+        guard let regex = try? Regex("[a-zA-Z]") else {
+            return []
+        }
+        
+        return [
+            ValidationRule(
+                regex: regex,
+                message: "Validation failed: Required only letters."
+            )
+        ]
+    }
+    
+    static var previews: some View {
+        Form {
+            Section {
+                Grid(horizontalSpacing: 8, verticalSpacing: 8) {
+                    UsernamePasswordFields(
+                        username: $username,
+                        password: $password,
+                        valid: $valid
+                    )
+                }
+            }
+            Section {
+                Grid(horizontalSpacing: 8, verticalSpacing: 8) {
+                    UsernamePasswordFields(
+                        username: $username,
+                        password: $password,
+                        valid: $valid
+                    )
+                }
+            }
+        }
+    }
+}
+#endif

--- a/UtahModules/Sources/UtahOnboardingFlow/AccountSetup/Utils/ValidationRule.swift
+++ b/UtahModules/Sources/UtahOnboardingFlow/AccountSetup/Utils/ValidationRule.swift
@@ -1,0 +1,60 @@
+//
+// This source file is part of the CardinalKit open-source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+
+/// A rule used for validating text along with a message to display if the validation fails.
+///
+/// The following example demonstrates a ``ValidationRule`` using a regex expression for an email.
+/// ```swift
+/// ValidationRule(
+///     regex: try? Regex("[A-Z0-9a-z._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,64}"),
+///     message: "The entered email is not correct."
+/// )
+/// ```
+public struct ValidationRule: Decodable {
+    enum CodingKeys: String, CodingKey {
+        case rule
+        case message
+    }
+    
+    
+    private let rule: (String) -> Bool
+    private let message: String
+    
+    /// Creates a validation rule from a regular expression
+    ///
+    /// - Parameters:
+    ///   - regex: A `Regex` regular expression to match for validating text
+    ///   - message: A `String` message to display if validation fails
+    public init(regex: Regex<AnyRegexOutput>, message: String) {
+        self.rule = { input in
+            (try? regex.wholeMatch(in: input) != nil) ?? false
+        }
+        self.message = message
+    }
+    
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        
+        let regexString = try values.decode(String.self, forKey: .rule)
+        let regex = try Regex<AnyRegexOutput>(regexString)
+        
+        let message = try values.decode(String.self, forKey: .message)
+        
+        self.init(regex: regex, message: message)
+    }
+    
+    /// Validates the contents of a `String` and returns a `String` error message if validation fails
+    func validate(_ input: String) -> String? {
+        guard !rule(input) else {
+            return nil
+        }
+        
+        return message
+    }
+}

--- a/UtahModules/Sources/UtahOnboardingFlow/AccountSetup/Utils/VerifiableTextRow.swift
+++ b/UtahModules/Sources/UtahOnboardingFlow/AccountSetup/Utils/VerifiableTextRow.swift
@@ -1,0 +1,179 @@
+//
+// This source file is part of the CardinalKit open-source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+import Views
+
+struct VerifiableTextRow<Description: View, TextField: View>: View {
+    private let description: Description
+    private let textField: TextField
+    private let validationRules: [ValidationRule]
+    
+    @Binding private var text: String
+    @Binding private var valid: Bool
+    
+    @State private var debounceTask: Task<Void, Never>? {
+        willSet {
+            self.debounceTask?.cancel()
+        }
+    }
+    @State private var validationResults: [String] = []
+    
+    
+    var body: some View {
+        DescriptionGridRow {
+            description
+        } content: {
+            VStack {
+                textField
+                    .onSubmit {
+                        validation()
+                    }
+                HStack {
+                    VStack(alignment: .leading) {
+                        ForEach(validationResults, id: \.self) { message in
+                            Text(message)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
+                        .gridColumnAlignment(.leading)
+                        .font(.footnote)
+                        .foregroundColor(.red)
+                    Spacer(minLength: 0)
+                }
+            }
+        }
+            .onChange(of: text) { _ in
+                validation()
+            }
+            .onTapFocus()
+    }
+    
+    
+    init(
+        text: Binding<String>,
+        valid: Binding<Bool>,
+        validationRules: [ValidationRule] = [],
+        @ViewBuilder description: () -> Description,
+        @ViewBuilder textField: (Binding<String>) -> TextField
+    ) {
+        self._text = text
+        self._valid = valid
+        self.validationRules = validationRules
+        self.description = description()
+        self.textField = textField(text)
+    }
+    
+    // We want to have the same argument order as found in the main initializer. We do not move the description property up as it constructs a trailing closure in the main initializer.
+    // swiftlint:disable:next function_default_parameter_at_end
+    init(
+        text: Binding<String>,
+        valid: Binding<Bool>,
+        validationRules: [ValidationRule] = [],
+        description: String,
+        @ViewBuilder textField: (Binding<String>) -> TextField
+    ) where Description == Text {
+        self.init(
+            text: text,
+            valid: valid,
+            description: { Text(description) },
+            textField: textField
+        )
+    }
+    
+    
+    private func validation() {
+        debounceTask = Task {
+            // Wait 0.5 seconds until you start the validation.
+            try? await Task.sleep(for: .seconds(0.2))
+            
+            guard !Task.isCancelled else {
+                return
+            }
+            
+            SwiftUI.withAnimation(.easeInOut(duration: 0.2)) {
+                defer {
+                    updateValid()
+                }
+                
+                guard !text.isEmpty else {
+                    validationResults = []
+                    return
+                }
+                
+                validationResults = validationRules.compactMap { $0.validate(text) }
+            }
+            
+            self.debounceTask = nil
+        }
+    }
+    
+    private func updateValid() {
+        valid = !text.isEmpty && validationResults.isEmpty
+    }
+}
+
+
+#if DEBUG
+struct VerifiableTextRow_Previews: PreviewProvider {
+    private enum Field: Hashable {
+        case first
+        case second
+    }
+    
+    
+    @State private static var text: String = ""
+    @State private static var valid = false
+    @FocusState private static var focusedField: Field?
+    
+    
+    static var previews: some View {
+        VStack {
+            Form {
+                views
+                    .padding(4)
+            }
+            views
+                .padding(32)
+        }
+            .background(Color(.systemGroupedBackground))
+    }
+    
+    private static var views: some View {
+        Grid(horizontalSpacing: 8, verticalSpacing: 8) {
+            VerifiableTextRow(
+                text: $text,
+                valid: $valid,
+                description: {
+                    Text("Text")
+                },
+                textField: { binding in
+                    TextField(text: binding) {
+                        Text("Placeholder ...")
+                    }
+                }
+            )
+                .onTapFocus(focusedField: _focusedField, fieldIdentifier: .first)
+            Divider()
+            VerifiableTextRow(
+                text: $text,
+                valid: $valid,
+                description: {
+                    Text("Text")
+                },
+                textField: { binding in
+                    SecureField(text: binding) {
+                        Text("Secure Placeholder ...")
+                    }
+                }
+            )
+                .onTapFocus(focusedField: _focusedField, fieldIdentifier: .first)
+        }
+    }
+}
+#endif

--- a/UtahModules/Sources/UtahOnboardingFlow/OnboardingFlow.swift
+++ b/UtahModules/Sources/UtahOnboardingFlow/OnboardingFlow.swift
@@ -19,6 +19,7 @@ public struct OnboardingFlow: View {
         case login
         case signUp
         case healthKitPermissions
+        case userInfo
     }
     
     
@@ -42,6 +43,8 @@ public struct OnboardingFlow: View {
                         UtahSignUp()
                     case .healthKitPermissions:
                         HealthKitPermissions()
+                    case .userInfo:
+                        UserInfoSignUp()
                     }
                 }
                 .navigationBarTitleDisplayMode(.inline)

--- a/UtahModules/Sources/UtahOnboardingFlow/OnboardingFlow.swift
+++ b/UtahModules/Sources/UtahOnboardingFlow/OnboardingFlow.swift
@@ -19,7 +19,6 @@ public struct OnboardingFlow: View {
         case login
         case signUp
         case healthKitPermissions
-        case userInfo
     }
     
     
@@ -40,11 +39,9 @@ public struct OnboardingFlow: View {
                     case .login:
                         UtahLogin()
                     case .signUp:
-                        UtahSignUp()
+                        UserInfoSignUp()
                     case .healthKitPermissions:
                         HealthKitPermissions()
-                    case .userInfo:
-                        UserInfoSignUp()
                     }
                 }
                 .navigationBarTitleDisplayMode(.inline)


### PR DESCRIPTION
<!--

This source file is part of the Stanford CS342 - Building for Digital Health class

SPDX-FileCopyrightText: 2022 Stanford University

SPDX-License-Identifier: MIT

-->

# Additional SignUp Screen

## :recycle: Current situation & Problem
Need to get the users name and disease when they sign up

## :bulb: Proposed solution
Make a new sign up page (UI for now)

## :gear: Release Notes 

## :heavy_plus_sign: Additional Information

### Related PRs

### Testing
Will add in a second
<img width="245" alt="Screenshot 2023-02-16 at 8 55 46 PM" src="https://user-images.githubusercontent.com/68484673/219552901-cea1a15e-c62f-4320-b1de-891aba7edfe8.png">


### Reviewer Nudging
n/a

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).

