### PR TITLE
Initial Implementation of ResearchKit Survey Frontend

### DIFF
--- a/Utah.xcodeproj/project.pbxproj
+++ b/Utah.xcodeproj/project.pbxproj
@@ -373,6 +373,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		93CD053C29A1B45400CC9DFB /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/Utah.xcodeproj/project.pbxproj
+++ b/Utah.xcodeproj/project.pbxproj
@@ -379,6 +379,7 @@
 			inputFileListPaths = (
 			);
 			inputPaths = (
+				"",
 			);
 			outputFileListPaths = (
 			);
@@ -386,7 +387,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+			shellScript = "export PATH=\"$PATH:/opt/homebrew/bin\"\nif which swiftlint > /dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/Utah.xcodeproj/project.pbxproj
+++ b/Utah.xcodeproj/project.pbxproj
@@ -19,7 +19,6 @@
 		2F4E237E2989A2FE0013F3D9 /* OnboardingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F4E237D2989A2FE0013F3D9 /* OnboardingTests.swift */; };
 		2F4E23812989C5930013F3D9 /* XCTHealthKit in Frameworks */ = {isa = PBXBuildFile; productRef = 2F4E23802989C5930013F3D9 /* XCTHealthKit */; };
 		2F4E23832989D51F0013F3D9 /* UtahAppTestingSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F4E23822989D51F0013F3D9 /* UtahAppTestingSetup.swift */; };
-		2F4E23852989D9130013F3D9 /* XCUIApplication+DeleteAndLaunch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F4E23842989D9130013F3D9 /* XCUIApplication+DeleteAndLaunch.swift */; };
 		2F4E23892989DB400013F3D9 /* HealthKitUploadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F4E23882989DB400013F3D9 /* HealthKitUploadTests.swift */; };
 		2F59B93F298C628800C5107F /* UtahMockDataStorageProvider in Frameworks */ = {isa = PBXBuildFile; productRef = 2F59B93E298C628800C5107F /* UtahMockDataStorageProvider */; };
 		2F59B941298C628800C5107F /* UtahOnboardingFlow in Frameworks */ = {isa = PBXBuildFile; productRef = 2F59B940298C628800C5107F /* UtahOnboardingFlow */; };
@@ -38,6 +37,9 @@
 		653A255528338800005D4D48 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 653A255428338800005D4D48 /* Assets.xcassets */; };
 		653A256228338800005D4D48 /* UtahTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653A256128338800005D4D48 /* UtahTests.swift */; };
 		653A256C28338800005D4D48 /* SchedulerAndQuestionnaireTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 653A256B28338800005D4D48 /* SchedulerAndQuestionnaireTests.swift */; };
+		93CD053729A0430400CC9DFB /* ResearchKit in Frameworks */ = {isa = PBXBuildFile; productRef = 93CD053629A0430400CC9DFB /* ResearchKit */; };
+		93CD053929A0548B00CC9DFB /* EdmontonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93CD053829A0548B00CC9DFB /* EdmontonTests.swift */; };
+		93CD053B29A0595A00CC9DFB /* WIQTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93CD053A29A0595A00CC9DFB /* WIQTests.swift */; };
 		93E00344298DC9EB00D6E494 /* UtahProfile in Frameworks */ = {isa = PBXBuildFile; productRef = 93E00343298DC9EB00D6E494 /* UtahProfile */; };
 		93E00346298DCF6400D6E494 /* UtahTrends in Frameworks */ = {isa = PBXBuildFile; productRef = 93E00345298DCF6400D6E494 /* UtahTrends */; };
 		93E00349298DFA8200D6E494 /* ProfileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93E00348298DFA8200D6E494 /* ProfileTests.swift */; };
@@ -66,7 +68,6 @@
 		2F49B77329803E8F00BCB272 /* UtahModules */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = UtahModules; sourceTree = "<group>"; };
 		2F4E237D2989A2FE0013F3D9 /* OnboardingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingTests.swift; sourceTree = "<group>"; };
 		2F4E23822989D51F0013F3D9 /* UtahAppTestingSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtahAppTestingSetup.swift; sourceTree = "<group>"; };
-		2F4E23842989D9130013F3D9 /* XCUIApplication+DeleteAndLaunch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "XCUIApplication+DeleteAndLaunch.swift"; sourceTree = "<group>"; };
 		2F4E23882989DB400013F3D9 /* HealthKitUploadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HealthKitUploadTests.swift; sourceTree = "<group>"; };
 		2F5E32BC297E05EA003432F8 /* UtahAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtahAppDelegate.swift; sourceTree = "<group>"; };
 		2F905717299E4205003D3802 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
@@ -82,6 +83,8 @@
 		653A256728338800005D4D48 /* UtahUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UtahUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		653A256B28338800005D4D48 /* SchedulerAndQuestionnaireTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SchedulerAndQuestionnaireTests.swift; sourceTree = "<group>"; };
 		653A258928339462005D4D48 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		93CD053829A0548B00CC9DFB /* EdmontonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EdmontonTests.swift; sourceTree = "<group>"; };
+		93CD053A29A0595A00CC9DFB /* WIQTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WIQTests.swift; sourceTree = "<group>"; };
 		93E00348298DFA8200D6E494 /* ProfileTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileTests.swift; sourceTree = "<group>"; };
 		93E0034A298DFAF200D6E494 /* TrendsTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TrendsTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -95,6 +98,7 @@
 				2F49B7822980419C00BCB272 /* Questionnaires in Frameworks */,
 				2F905715299E3E0D003D3802 /* FirestoreStoragePrefixUserIdAdapter in Frameworks */,
 				2F49B77E2980407C00BCB272 /* Scheduler in Frameworks */,
+				93CD053729A0430400CC9DFB /* ResearchKit in Frameworks */,
 				2F59B93F298C628800C5107F /* UtahMockDataStorageProvider in Frameworks */,
 				2F49B77A2980407C00BCB272 /* HealthKitDataSource in Frameworks */,
 				2F59B945298C628800C5107F /* UtahSharedContext in Frameworks */,
@@ -195,6 +199,8 @@
 				93E0034A298DFAF200D6E494 /* TrendsTests.swift */,
 				2F4E23882989DB400013F3D9 /* HealthKitUploadTests.swift */,
 				23B0449A299DB70A008CD957 /* GetUpAndGoTests.swift */,
+				93CD053829A0548B00CC9DFB /* EdmontonTests.swift */,
+				93CD053A29A0595A00CC9DFB /* WIQTests.swift */,
 			);
 			path = UtahUITests;
 			sourceTree = "<group>";
@@ -241,6 +247,7 @@
 				2F905710299E3E0D003D3802 /* FirebaseAccount */,
 				2F905712299E3E0D003D3802 /* FirestoreDataStorage */,
 				2F905714299E3E0D003D3802 /* FirestoreStoragePrefixUserIdAdapter */,
+				93CD053629A0430400CC9DFB /* ResearchKit */,
 			);
 			productName = UtahApplication;
 			productReference = 653A254D283387FE005D4D48 /* Utah.app */;
@@ -322,6 +329,7 @@
 				2F49B7742980407B00BCB272 /* XCRemoteSwiftPackageReference "CardinalKit" */,
 				2F4E237F2989C5930013F3D9 /* XCRemoteSwiftPackageReference "XCTHealthKit" */,
 				2F90570B299E3C69003D3802 /* XCRemoteSwiftPackageReference "XCTestExtensions" */,
+				93CD053529A0430400CC9DFB /* XCRemoteSwiftPackageReference "ResearchKit" */,
 			);
 			productRefGroup = 653A254E283387FE005D4D48 /* Products */;
 			projectDirPath = "";
@@ -385,10 +393,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				93CD053929A0548B00CC9DFB /* EdmontonTests.swift in Sources */,
 				93E0034B298DFAF200D6E494 /* TrendsTests.swift in Sources */,
 				23B0449B299DB70A008CD957 /* GetUpAndGoTests.swift in Sources */,
 				2F4E23892989DB400013F3D9 /* HealthKitUploadTests.swift in Sources */,
 				2F4E237E2989A2FE0013F3D9 /* OnboardingTests.swift in Sources */,
+				93CD053B29A0595A00CC9DFB /* WIQTests.swift in Sources */,
 				93E00349298DFA8200D6E494 /* ProfileTests.swift in Sources */,
 				653A256C28338800005D4D48 /* SchedulerAndQuestionnaireTests.swift in Sources */,
 			);
@@ -911,6 +921,14 @@
 				minimumVersion = 0.3.0;
 			};
 		};
+		93CD053529A0430400CC9DFB /* XCRemoteSwiftPackageReference "ResearchKit" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "git@github.com:StanfordBDHG/ResearchKit.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.0.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -999,6 +1017,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 2F49B7742980407B00BCB272 /* XCRemoteSwiftPackageReference "CardinalKit" */;
 			productName = FirestoreStoragePrefixUserIdAdapter;
+		};
+		93CD053629A0430400CC9DFB /* ResearchKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 93CD053529A0430400CC9DFB /* XCRemoteSwiftPackageReference "ResearchKit" */;
+			productName = ResearchKit;
 		};
 		93E00343298DC9EB00D6E494 /* UtahProfile */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Utah.xcodeproj/project.pbxproj
+++ b/Utah.xcodeproj/project.pbxproj
@@ -222,6 +222,7 @@
 				653A2549283387FE005D4D48 /* Sources */,
 				653A254A283387FE005D4D48 /* Frameworks */,
 				653A254B283387FE005D4D48 /* Resources */,
+				93CD053C29A1B45400CC9DFB /* ShellScript */,
 			);
 			buildRules = (
 			);
@@ -368,6 +369,26 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		93CD053C29A1B45400CC9DFB /* ShellScript */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n  swiftlint\nelse\n  echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		653A2549283387FE005D4D48 /* Sources */ = {

--- a/UtahModules/Sources/UtahSchedule/Edmonton/EdmontonViewController.swift
+++ b/UtahModules/Sources/UtahSchedule/Edmonton/EdmontonViewController.swift
@@ -1,0 +1,140 @@
+//
+// This source file is part of the CS342 2023 Utah Team Application project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+import UIKit
+import ResearchKit
+
+struct EdmontonViewController: UIViewControllerRepresentable {
+    
+    typealias UIViewControllerType = ORKTaskViewController
+    
+    func makeCoordinator() -> EdmontonViewCoordinator {
+        EdmontonViewCoordinator()
+    }
+    
+    func updateUIViewController(_ taskViewController: ORKTaskViewController, context: Context) {}
+    
+    func makeUIViewController(context: Context) -> ORKTaskViewController {
+
+        let sampleSurveyTask: ORKOrderedTask = {
+            var steps = [ORKStep]()
+            
+            // Instruction step
+            let instructionStep = ORKInstructionStep(identifier: "IntroStep")
+            instructionStep.title = "Patient Questionnaire"
+            instructionStep.text = "This information will help your doctors keep track of how you feel and how well you are able to do your usual activities. If you are unsure about how to answer a question, please give the best answer you can and make a written comment beside your answer."
+            
+            steps += [instructionStep]
+            
+            // Clock test step
+            let clockTestInstructionStep = ORKInstructionStep(identifier: "ClockStep")
+            clockTestInstructionStep.title = "Draw a clock"
+            clockTestInstructionStep.text = "Place numbers the correct positions on a pre-drawn circle, and place hands to indicate the time of ‘ten after eleven’. Upload a photo in the next step"
+            
+            steps += [clockTestInstructionStep]
+            
+            // Image capture step
+            
+            let imageCaptureStep = ORKImageCaptureStep(identifier: "ImageCaptureStep") // we should add a circle template image here
+            
+            steps += [imageCaptureStep]
+            
+//            //In general, would you say your health is:
+//            let healthScaleAnswerFormat = ORKAnswerFormat.scale(withMaximumValue: 5, minimumValue: 1, defaultValue: 3, step: 1, vertical: false, maximumValueDescription: "Excellent", minimumValueDescription: "Poor")
+//            let healthScaleQuestionStep = ORKQuestionStep(identifier: "HealthScaleQuestionStep", title: "Question #1", question: "In general, would you say your health is:", answer: healthScaleAnswerFormat)
+//
+//            steps += [healthScaleQuestionStep]
+            
+            // Question 2
+            let q2Choices = [
+                ORKTextChoice(text: "0", value: 0 as NSNumber),
+                ORKTextChoice(text: "1-2", value: 1 as NSNumber),
+                ORKTextChoice(text: ">2", value: 2 as NSNumber)
+            ]
+            let q2ChoiceAnswerFormat = ORKAnswerFormat.choiceAnswerFormat(with: .singleChoice, textChoices: q2Choices)
+            let q2Step = ORKQuestionStep(identifier: "q2", title: "", question: "In the past year, how many times have you been admitted to a hospital?", answer: q2ChoiceAnswerFormat)
+            q2Step.isOptional = false
+            
+            steps += [q2Step]
+            
+            // Question 3
+            let q3Choices = [
+                ORKTextChoice(text: "Excellent", value: 0 as NSNumber),
+                ORKTextChoice(text: "Very Good", value: 0 as NSNumber),
+                ORKTextChoice(text: "Good", value: 0 as NSNumber),
+                ORKTextChoice(text: "Fair", value: 1 as NSNumber),
+                ORKTextChoice(text: "Poor", value: 2 as NSNumber)
+            ]
+            let q3ChoiceAnswerFormat = ORKAnswerFormat.choiceAnswerFormat(with: .singleChoice, textChoices: q3Choices)
+            let q3Step = ORKQuestionStep(identifier: "q3", title: "", question: "In general, how would you describe your health?", answer: q3ChoiceAnswerFormat)
+            q3Step.isOptional = false
+            
+            steps += [q3Step]
+            
+            // Question 4
+            let q4Choices = [
+                ORKTextChoice(text: "0-1", value: 0 as NSNumber),
+                ORKTextChoice(text: "2-4", value: 1 as NSNumber),
+                ORKTextChoice(text: "5-8", value: 2 as NSNumber)
+            ]
+            let q4ChoiceAnswerFormat = ORKAnswerFormat.choiceAnswerFormat(with: .singleChoice, textChoices: q4Choices)
+            let q4Step = ORKQuestionStep(identifier: "q4", title: "", question: "With how many of the following activities do you require help? (meal preparation, shopping, transportation, telephone, housekeeping, laundry, managing money, taking medications)", answer: q4ChoiceAnswerFormat)
+            q4Step.isOptional = false
+            
+            steps += [q4Step]
+
+            // Question 5
+            let q5Choices = [
+                ORKTextChoice(text: "Always", value: 0 as NSNumber),
+                ORKTextChoice(text: "Sometimes", value: 1 as NSNumber),
+                ORKTextChoice(text: "Never", value: 2 as NSNumber)
+            ]
+            let q5ChoiceAnswerFormat = ORKAnswerFormat.choiceAnswerFormat(with: .singleChoice, textChoices: q5Choices)
+            let q5Step = ORKQuestionStep(identifier: "q5", title: "", question: "When you need help, can you count on someone who is willing and able to meet your needs?", answer: q5ChoiceAnswerFormat)
+            q5Step.isOptional = false
+            
+            steps += [q5Step]
+            
+            // Question 6-10
+            let q6to10Choices = [
+                ORKTextChoice(text: "Yes", value: 1 as NSNumber),
+                ORKTextChoice(text: "No", value: 0 as NSNumber)
+            ]
+            let q6to10ChoiceAnswerFormat = ORKAnswerFormat.choiceAnswerFormat(with: .singleChoice, textChoices: q6to10Choices)
+            let q6Step = ORKQuestionStep(identifier: "q6", title: "", question: "Do you use five or more different prescription medications on a regular basis?", answer: q6to10ChoiceAnswerFormat)
+            q6Step.isOptional = false
+            let q7Step = ORKQuestionStep(identifier: "q7", title: "", question: "At times, do you forget to take your prescription medications?", answer: q6to10ChoiceAnswerFormat)
+            q7Step.isOptional = false
+            let q8Step = ORKQuestionStep(identifier: "q8", title: "", question: "Have you recently lost weight such that your clothing has become looser?", answer: q6to10ChoiceAnswerFormat)
+            q8Step.isOptional = false
+            let q9Step = ORKQuestionStep(identifier: "q9", title: "", question: "Do you often feel sad or depressed?", answer: q6to10ChoiceAnswerFormat)
+            q9Step.isOptional = false
+            let q10Step = ORKQuestionStep(identifier: "q10", title: "", question: "Do you have a problem with losing control of urine when you don’t want to?", answer: q6to10ChoiceAnswerFormat)
+            q10Step.isOptional = false
+            
+            steps += [q6Step, q7Step, q8Step, q9Step, q10Step]
+            
+            //SUMMARY
+            let summaryStep = ORKCompletionStep(identifier: "SummaryStep")
+            summaryStep.title = "Thank you."
+            summaryStep.text = "We appreciate your time."
+            
+            steps += [summaryStep]
+            
+            return ORKOrderedTask(identifier: "SurveyTask-Assessment", steps: steps)
+        }()
+        
+        let taskViewController = ORKTaskViewController(task: sampleSurveyTask, taskRun: nil)
+        taskViewController.delegate = context.coordinator
+        
+        // & present the VC!
+        return taskViewController
+    }
+    
+}

--- a/UtahModules/Sources/UtahSchedule/Edmonton/EdmontonViewController.swift
+++ b/UtahModules/Sources/UtahSchedule/Edmonton/EdmontonViewController.swift
@@ -7,11 +7,10 @@
 //
 
 import SwiftUI
-import UIKit
 import ResearchKit
+import UIKit
 
 struct EdmontonViewController: UIViewControllerRepresentable {
-    
     typealias UIViewControllerType = ORKTaskViewController
     
     func makeCoordinator() -> EdmontonViewCoordinator {
@@ -21,21 +20,27 @@ struct EdmontonViewController: UIViewControllerRepresentable {
     func updateUIViewController(_ taskViewController: ORKTaskViewController, context: Context) {}
     
     func makeUIViewController(context: Context) -> ORKTaskViewController {
-
         let sampleSurveyTask: ORKOrderedTask = {
             var steps = [ORKStep]()
             
             // Instruction step
             let instructionStep = ORKInstructionStep(identifier: "IntroStep")
             instructionStep.title = "Patient Questionnaire"
-            instructionStep.text = "This information will help your doctors keep track of how you feel and how well you are able to do your usual activities. If you are unsure about how to answer a question, please give the best answer you can and make a written comment beside your answer."
+            instructionStep.text = """
+            This information will help your doctors keep track of how you feel and how well you are able
+            to do your usual activities. If you are unsure about how to answer a question, please give the
+            best answer you can and make a written comment beside your answer.
+            """
             
             steps += [instructionStep]
             
             // Clock test step
             let clockTestInstructionStep = ORKInstructionStep(identifier: "ClockStep")
             clockTestInstructionStep.title = "Draw a clock"
-            clockTestInstructionStep.text = "Place numbers the correct positions on a pre-drawn circle, and place hands to indicate the time of ‘ten after eleven’. Upload a photo in the next step"
+            clockTestInstructionStep.text = """
+            Place numbers the correct positions on a pre-drawn circle, and place hands to
+            indicate the time of ‘ten after eleven’. Upload a photo in the next step
+            """
             
             steps += [clockTestInstructionStep]
             
@@ -45,12 +50,6 @@ struct EdmontonViewController: UIViewControllerRepresentable {
             
             steps += [imageCaptureStep]
             
-//            //In general, would you say your health is:
-//            let healthScaleAnswerFormat = ORKAnswerFormat.scale(withMaximumValue: 5, minimumValue: 1, defaultValue: 3, step: 1, vertical: false, maximumValueDescription: "Excellent", minimumValueDescription: "Poor")
-//            let healthScaleQuestionStep = ORKQuestionStep(identifier: "HealthScaleQuestionStep", title: "Question #1", question: "In general, would you say your health is:", answer: healthScaleAnswerFormat)
-//
-//            steps += [healthScaleQuestionStep]
-            
             // Question 2
             let q2Choices = [
                 ORKTextChoice(text: "0", value: 0 as NSNumber),
@@ -58,7 +57,12 @@ struct EdmontonViewController: UIViewControllerRepresentable {
                 ORKTextChoice(text: ">2", value: 2 as NSNumber)
             ]
             let q2ChoiceAnswerFormat = ORKAnswerFormat.choiceAnswerFormat(with: .singleChoice, textChoices: q2Choices)
-            let q2Step = ORKQuestionStep(identifier: "q2", title: "", question: "In the past year, how many times have you been admitted to a hospital?", answer: q2ChoiceAnswerFormat)
+            let q2Step = ORKQuestionStep(
+                identifier: "q2",
+                title: "",
+                question: "In the past year, how many times have you been admitted to a hospital?",
+                answer: q2ChoiceAnswerFormat
+            )
             q2Step.isOptional = false
             
             steps += [q2Step]
@@ -72,7 +76,12 @@ struct EdmontonViewController: UIViewControllerRepresentable {
                 ORKTextChoice(text: "Poor", value: 2 as NSNumber)
             ]
             let q3ChoiceAnswerFormat = ORKAnswerFormat.choiceAnswerFormat(with: .singleChoice, textChoices: q3Choices)
-            let q3Step = ORKQuestionStep(identifier: "q3", title: "", question: "In general, how would you describe your health?", answer: q3ChoiceAnswerFormat)
+            let q3Step = ORKQuestionStep(
+                identifier: "q3",
+                title: "",
+                question: "In general, how would you describe your health?",
+                answer: q3ChoiceAnswerFormat
+            )
             q3Step.isOptional = false
             
             steps += [q3Step]
@@ -84,7 +93,15 @@ struct EdmontonViewController: UIViewControllerRepresentable {
                 ORKTextChoice(text: "5-8", value: 2 as NSNumber)
             ]
             let q4ChoiceAnswerFormat = ORKAnswerFormat.choiceAnswerFormat(with: .singleChoice, textChoices: q4Choices)
-            let q4Step = ORKQuestionStep(identifier: "q4", title: "", question: "With how many of the following activities do you require help? (meal preparation, shopping, transportation, telephone, housekeeping, laundry, managing money, taking medications)", answer: q4ChoiceAnswerFormat)
+            let q4Step = ORKQuestionStep(
+                identifier: "q4",
+                title: "",
+                question: """
+                    With how many of the following activities do you require help? (meal preparation, shopping, transportation, telephone,
+                    housekeeping, laundry, managing money, taking medications)
+                    """,
+                answer: q4ChoiceAnswerFormat
+            )
             q4Step.isOptional = false
             
             steps += [q4Step]
@@ -96,7 +113,12 @@ struct EdmontonViewController: UIViewControllerRepresentable {
                 ORKTextChoice(text: "Never", value: 2 as NSNumber)
             ]
             let q5ChoiceAnswerFormat = ORKAnswerFormat.choiceAnswerFormat(with: .singleChoice, textChoices: q5Choices)
-            let q5Step = ORKQuestionStep(identifier: "q5", title: "", question: "When you need help, can you count on someone who is willing and able to meet your needs?", answer: q5ChoiceAnswerFormat)
+            let q5Step = ORKQuestionStep(
+                identifier: "q5",
+                title: "",
+                question: "When you need help, can you count on someone who is willing and able to meet your needs?",
+                answer: q5ChoiceAnswerFormat
+            )
             q5Step.isOptional = false
             
             steps += [q5Step]
@@ -107,20 +129,45 @@ struct EdmontonViewController: UIViewControllerRepresentable {
                 ORKTextChoice(text: "No", value: 0 as NSNumber)
             ]
             let q6to10ChoiceAnswerFormat = ORKAnswerFormat.choiceAnswerFormat(with: .singleChoice, textChoices: q6to10Choices)
-            let q6Step = ORKQuestionStep(identifier: "q6", title: "", question: "Do you use five or more different prescription medications on a regular basis?", answer: q6to10ChoiceAnswerFormat)
+            let q6Step = ORKQuestionStep(
+                identifier: "q6",
+                title: "",
+                question: "Do you use five or more different prescription medications on a regular basis?",
+                answer: q6to10ChoiceAnswerFormat
+            )
             q6Step.isOptional = false
-            let q7Step = ORKQuestionStep(identifier: "q7", title: "", question: "At times, do you forget to take your prescription medications?", answer: q6to10ChoiceAnswerFormat)
+            let q7Step = ORKQuestionStep(
+                identifier: "q7",
+                title: "",
+                question: "At times, do you forget to take your prescription medications?",
+                answer: q6to10ChoiceAnswerFormat
+            )
             q7Step.isOptional = false
-            let q8Step = ORKQuestionStep(identifier: "q8", title: "", question: "Have you recently lost weight such that your clothing has become looser?", answer: q6to10ChoiceAnswerFormat)
+            let q8Step = ORKQuestionStep(
+                identifier: "q8",
+                title: "",
+                question: "Have you recently lost weight such that your clothing has become looser?",
+                answer: q6to10ChoiceAnswerFormat
+            )
             q8Step.isOptional = false
-            let q9Step = ORKQuestionStep(identifier: "q9", title: "", question: "Do you often feel sad or depressed?", answer: q6to10ChoiceAnswerFormat)
+            let q9Step = ORKQuestionStep(
+                identifier: "q9",
+                title: "",
+                question: "Do you often feel sad or depressed?",
+                answer: q6to10ChoiceAnswerFormat
+            )
             q9Step.isOptional = false
-            let q10Step = ORKQuestionStep(identifier: "q10", title: "", question: "Do you have a problem with losing control of urine when you don’t want to?", answer: q6to10ChoiceAnswerFormat)
+            let q10Step = ORKQuestionStep(
+                identifier: "q10",
+                title: "",
+                question: "Do you have a problem with losing control of urine when you don’t want to?",
+                answer: q6to10ChoiceAnswerFormat
+            )
             q10Step.isOptional = false
             
             steps += [q6Step, q7Step, q8Step, q9Step, q10Step]
             
-            //SUMMARY
+            // SUMMARY
             let summaryStep = ORKCompletionStep(identifier: "SummaryStep")
             summaryStep.title = "Thank you."
             summaryStep.text = "We appreciate your time."

--- a/UtahModules/Sources/UtahSchedule/Edmonton/EdmontonViewController.swift
+++ b/UtahModules/Sources/UtahSchedule/Edmonton/EdmontonViewController.swift
@@ -6,8 +6,13 @@
 // SPDX-License-Identifier: MIT
 //
 
-import SwiftUI
+// swiftlint:disable function_body_length
+// swiftlint:disable closure_body_length
+// swiftlint:disable legacy_objc_type
+
+import Foundation
 import ResearchKit
+import SwiftUI
 import UIKit
 
 struct EdmontonViewController: UIViewControllerRepresentable {
@@ -20,7 +25,7 @@ struct EdmontonViewController: UIViewControllerRepresentable {
     func updateUIViewController(_ taskViewController: ORKTaskViewController, context: Context) {}
     
     func makeUIViewController(context: Context) -> ORKTaskViewController {
-        let sampleSurveyTask: ORKOrderedTask = {
+        let edmontonSurveyTask: ORKOrderedTask = {
             var steps = [ORKStep]()
             
             // Instruction step
@@ -31,9 +36,9 @@ struct EdmontonViewController: UIViewControllerRepresentable {
             to do your usual activities. If you are unsure about how to answer a question, please give the
             best answer you can and make a written comment beside your answer.
             """
-            
+
             steps += [instructionStep]
-            
+
             // Clock test step
             let clockTestInstructionStep = ORKInstructionStep(identifier: "ClockStep")
             clockTestInstructionStep.title = "Draw a clock"
@@ -41,7 +46,7 @@ struct EdmontonViewController: UIViewControllerRepresentable {
             Place numbers the correct positions on a pre-drawn circle, and place hands to
             indicate the time of ‘ten after eleven’. Upload a photo in the next step
             """
-            
+
             steps += [clockTestInstructionStep]
             
             // Image capture step
@@ -124,48 +129,25 @@ struct EdmontonViewController: UIViewControllerRepresentable {
             steps += [q5Step]
             
             // Question 6-10
-            let q6to10Choices = [
-                ORKTextChoice(text: "Yes", value: 1 as NSNumber),
-                ORKTextChoice(text: "No", value: 0 as NSNumber)
-            ]
+            let q6to10Choices = [ ORKTextChoice(text: "Yes", value: 1 as NSNumber), ORKTextChoice(text: "No", value: 0 as NSNumber) ]
             let q6to10ChoiceAnswerFormat = ORKAnswerFormat.choiceAnswerFormat(with: .singleChoice, textChoices: q6to10Choices)
-            let q6Step = ORKQuestionStep(
-                identifier: "q6",
-                title: "",
-                question: "Do you use five or more different prescription medications on a regular basis?",
-                answer: q6to10ChoiceAnswerFormat
-            )
-            q6Step.isOptional = false
-            let q7Step = ORKQuestionStep(
-                identifier: "q7",
-                title: "",
-                question: "At times, do you forget to take your prescription medications?",
-                answer: q6to10ChoiceAnswerFormat
-            )
-            q7Step.isOptional = false
-            let q8Step = ORKQuestionStep(
-                identifier: "q8",
-                title: "",
-                question: "Have you recently lost weight such that your clothing has become looser?",
-                answer: q6to10ChoiceAnswerFormat
-            )
-            q8Step.isOptional = false
-            let q9Step = ORKQuestionStep(
-                identifier: "q9",
-                title: "",
-                question: "Do you often feel sad or depressed?",
-                answer: q6to10ChoiceAnswerFormat
-            )
-            q9Step.isOptional = false
-            let q10Step = ORKQuestionStep(
-                identifier: "q10",
-                title: "",
-                question: "Do you have a problem with losing control of urine when you don’t want to?",
-                answer: q6to10ChoiceAnswerFormat
-            )
-            q10Step.isOptional = false
-            
-            steps += [q6Step, q7Step, q8Step, q9Step, q10Step]
+            let questions = [
+                "Do you use five or more different prescription medications on a regular basis?",
+                "At times, do you forget to take your prescription medications?",
+                "Have you recently lost weight such that your clothing has become looser?",
+                "Do you often feel sad or depressed?",
+                "Do you have a problem with losing control of urine when you don’t want to?"
+            ]
+            for (idx, question) in questions.enumerated() {
+                let qStep = ORKQuestionStep(
+                    identifier: String(format: "Edmonton %d", idx + 6),
+                    title: "",
+                    question: question,
+                    answer: q6to10ChoiceAnswerFormat
+                )
+                qStep.isOptional = false
+                steps += [qStep]
+            }
             
             // SUMMARY
             let summaryStep = ORKCompletionStep(identifier: "SummaryStep")
@@ -177,11 +159,10 @@ struct EdmontonViewController: UIViewControllerRepresentable {
             return ORKOrderedTask(identifier: "SurveyTask-Assessment", steps: steps)
         }()
         
-        let taskViewController = ORKTaskViewController(task: sampleSurveyTask, taskRun: nil)
+        let taskViewController = ORKTaskViewController(task: edmontonSurveyTask, taskRun: nil)
         taskViewController.delegate = context.coordinator
         
         // & present the VC!
         return taskViewController
     }
-    
 }

--- a/UtahModules/Sources/UtahSchedule/Edmonton/EdmontonViewCoordinator.swift
+++ b/UtahModules/Sources/UtahSchedule/Edmonton/EdmontonViewCoordinator.swift
@@ -6,6 +6,8 @@
 // SPDX-License-Identifier: MIT
 //
 
+// swiftlint:disable lower_acl_than_parent
+
 import Foundation
 import ResearchKit
 

--- a/UtahModules/Sources/UtahSchedule/Edmonton/EdmontonViewCoordinator.swift
+++ b/UtahModules/Sources/UtahSchedule/Edmonton/EdmontonViewCoordinator.swift
@@ -15,5 +15,3 @@ class EdmontonViewCoordinator: NSObject, ORKTaskViewControllerDelegate {
         taskViewController.dismiss(animated: true, completion: nil)
     }
 }
-
-

--- a/UtahModules/Sources/UtahSchedule/Edmonton/EdmontonViewCoordinator.swift
+++ b/UtahModules/Sources/UtahSchedule/Edmonton/EdmontonViewCoordinator.swift
@@ -11,7 +11,11 @@ import ResearchKit
 
 class EdmontonViewCoordinator: NSObject, ORKTaskViewControllerDelegate {
     // called when the survey is completed, need to figure out how to upload data to firestore
-    public func taskViewController(_ taskViewController: ORKTaskViewController, didFinishWith reason: ORKTaskViewControllerFinishReason, error: Error?) {
+    public func taskViewController(
+        _ taskViewController: ORKTaskViewController,
+        didFinishWith reason: ORKTaskViewControllerFinishReason,
+        error: Error?
+    ) {
         taskViewController.dismiss(animated: true, completion: nil)
     }
 }

--- a/UtahModules/Sources/UtahSchedule/Edmonton/EdmontonViewCoordinator.swift
+++ b/UtahModules/Sources/UtahSchedule/Edmonton/EdmontonViewCoordinator.swift
@@ -1,0 +1,19 @@
+//
+// This source file is part of the CS342 2023 Utah Team Application project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import ResearchKit
+
+class EdmontonViewCoordinator: NSObject, ORKTaskViewControllerDelegate {
+    // called when the survey is completed, need to figure out how to upload data to firestore
+    public func taskViewController(_ taskViewController: ORKTaskViewController, didFinishWith reason: ORKTaskViewControllerFinishReason, error: Error?) {
+        taskViewController.dismiss(animated: true, completion: nil)
+    }
+}
+
+

--- a/UtahModules/Sources/UtahSchedule/Resources/en.lproj/Localizable.strings
+++ b/UtahModules/Sources/UtahSchedule/Resources/en.lproj/Localizable.strings
@@ -18,3 +18,4 @@
 "GET_UP_AND_GO_WARNING" = "Do not do this alone. Please have someone by you to help you if necessary.";
 "GET_UP_AND_GO_START_BUTTON" = "Start";
 
+

--- a/UtahModules/Sources/UtahSchedule/ScheduleView.swift
+++ b/UtahModules/Sources/UtahSchedule/ScheduleView.swift
@@ -15,11 +15,45 @@ public struct ScheduleView: View {
     @EnvironmentObject var scheduler: UtahScheduler
     @State var eventContextsByDate: [Date: [EventContext]] = [:]
     @State var presentedContext: EventContext?
-    @State private var showingSurvey = false
-    @State private var showingSurvey2 = false
+    @State private var showingEdmontonSurvey = false
+    @State private var showingWIQSurvey = false
     
     var startOfDays: [Date] {
         Array(eventContextsByDate.keys)
+    }
+    
+    private var temporyButtons: some View {
+        VStack {
+            Button("Edmonton Frail Scale") {
+                showingEdmontonSurvey.toggle()
+            }
+            .foregroundColor(Color.white)
+            .padding()
+            .background(.red)
+            .cornerRadius(10)
+            .sheet(isPresented: $showingEdmontonSurvey) {
+                EdmontonViewController()
+            }
+            .padding(.top, 60)
+            Button("Walking Impairement Questionnaire") {
+                showingWIQSurvey.toggle()
+            }
+            .foregroundColor(Color.white)
+            .padding()
+            .background(.blue)
+            .cornerRadius(10)
+            .sheet(isPresented: $showingWIQSurvey) {
+                WIQViewController()
+            }
+            NavigationLink(destination: GetUpAndGo()) {
+                Text("Get Up And Go Question")
+            }.frame(alignment: .topLeading)
+                .padding(.all, 15)
+                .foregroundColor(Color.white)
+                .background(.green)
+                .cornerRadius(15)
+                .navigationTitle(String(localized: "QUESTIONNAIRE_LIST_TITLE", bundle: .module))
+        }
     }
     
     public var body: some View {
@@ -46,39 +80,7 @@ public struct ScheduleView: View {
                 .sheet(item: $presentedContext) { presentedContext in
                     destination(withContext: presentedContext)
                 }
-                VStack{
-                    Button("Edmonton Frail Scale"){
-                        showingSurvey.toggle()
-                    }
-                    .foregroundColor(Color.white)
-                    .padding()
-                    .background(.red)
-                    .cornerRadius(10)
-                    .sheet(isPresented: $showingSurvey){
-                        EdmontonViewController()
-                    }
-                    Button("Walking Impairement Questionnaire"){
-                        showingSurvey2.toggle()
-                    }
-                    .foregroundColor(Color.white)
-                    .padding()
-                    .background(.blue)
-                    .cornerRadius(10)
-                    .sheet(isPresented: $showingSurvey2){
-                        WIQViewController()
-                    }
-                    NavigationLink(destination: GetUpAndGo()) {
-                        Text("Get Up And Go Question")
-                    }.frame(alignment: .topLeading)
-                        .padding(.all, 10)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 25)
-                                .stroke(Color.white, lineWidth: 2)
-                        )
-                        .background(Color(.white))
-                        .cornerRadius(25)
-                        .navigationTitle(String(localized: "QUESTIONNAIRE_LIST_TITLE", bundle: .module))
-                }
+                temporyButtons
             }
         }
     }

--- a/UtahModules/Sources/UtahSchedule/ScheduleView.swift
+++ b/UtahModules/Sources/UtahSchedule/ScheduleView.swift
@@ -6,6 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
+// swiftlint:disable closure_body_length
 
 import Questionnaires
 import Scheduler
@@ -17,6 +18,7 @@ public struct ScheduleView: View {
     @State var presentedContext: EventContext?
     @State private var showingEdmontonSurvey = false
     @State private var showingWIQSurvey = false
+    @State private var showingTimedWalk = false
     
     var startOfDays: [Date] {
         Array(eventContextsByDate.keys)
@@ -34,7 +36,7 @@ public struct ScheduleView: View {
             .sheet(isPresented: $showingEdmontonSurvey) {
                 EdmontonViewController()
             }
-            .padding(.top, 60)
+            .padding(.top, 130)
             Button("Walking Impairement Questionnaire") {
                 showingWIQSurvey.toggle()
             }
@@ -44,6 +46,16 @@ public struct ScheduleView: View {
             .cornerRadius(10)
             .sheet(isPresented: $showingWIQSurvey) {
                 WIQViewController()
+            }
+            Button("Timed Walk (ResearchKit)") {
+                showingTimedWalk.toggle()
+            }
+            .foregroundColor(Color.white)
+            .padding()
+            .background(.pink)
+            .cornerRadius(10)
+            .sheet(isPresented: $showingTimedWalk) {
+                TimedWalkViewController()
             }
             NavigationLink(destination: GetUpAndGo()) {
                 Text("Get Up And Go Question")

--- a/UtahModules/Sources/UtahSchedule/ScheduleView.swift
+++ b/UtahModules/Sources/UtahSchedule/ScheduleView.swift
@@ -18,7 +18,6 @@ public struct ScheduleView: View {
     @State private var showingSurvey = false
     @State private var showingSurvey2 = false
     
-    
     var startOfDays: [Date] {
         Array(eventContextsByDate.keys)
     }

--- a/UtahModules/Sources/UtahSchedule/ScheduleView.swift
+++ b/UtahModules/Sources/UtahSchedule/ScheduleView.swift
@@ -11,17 +11,17 @@ import Questionnaires
 import Scheduler
 import SwiftUI
 
-
 public struct ScheduleView: View {
     @EnvironmentObject var scheduler: UtahScheduler
     @State var eventContextsByDate: [Date: [EventContext]] = [:]
     @State var presentedContext: EventContext?
+    @State private var showingSurvey = false
+    @State private var showingSurvey2 = false
     
     
     var startOfDays: [Date] {
         Array(eventContextsByDate.keys)
     }
-    
     
     public var body: some View {
         NavigationStack {
@@ -47,17 +47,39 @@ public struct ScheduleView: View {
                 .sheet(item: $presentedContext) { presentedContext in
                     destination(withContext: presentedContext)
                 }
-                NavigationLink(destination: GetUpAndGo()) {
-                                    Text("Get Up And Go Question")
-                }.frame(alignment: .topLeading)
-                    .padding(.all, 10)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 25)
-                        .stroke(Color.white, lineWidth: 2)
-                )
-                    .background(Color(.white))
-                    .cornerRadius(25)
-                .navigationTitle(String(localized: "QUESTIONNAIRE_LIST_TITLE", bundle: .module))
+                VStack{
+                    Button("Edmonton Frail Scale"){
+                        showingSurvey.toggle()
+                    }
+                    .foregroundColor(Color.white)
+                    .padding()
+                    .background(.red)
+                    .cornerRadius(10)
+                    .sheet(isPresented: $showingSurvey){
+                        EdmontonViewController()
+                    }
+                    Button("Walking Impairement Questionnaire"){
+                        showingSurvey2.toggle()
+                    }
+                    .foregroundColor(Color.white)
+                    .padding()
+                    .background(.blue)
+                    .cornerRadius(10)
+                    .sheet(isPresented: $showingSurvey2){
+                        WIQViewController()
+                    }
+                    NavigationLink(destination: GetUpAndGo()) {
+                        Text("Get Up And Go Question")
+                    }.frame(alignment: .topLeading)
+                        .padding(.all, 10)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 25)
+                                .stroke(Color.white, lineWidth: 2)
+                        )
+                        .background(Color(.white))
+                        .cornerRadius(25)
+                        .navigationTitle(String(localized: "QUESTIONNAIRE_LIST_TITLE", bundle: .module))
+                }
             }
         }
     }

--- a/UtahModules/Sources/UtahSchedule/TimedWalk/TimedWalkViewController.swift
+++ b/UtahModules/Sources/UtahSchedule/TimedWalk/TimedWalkViewController.swift
@@ -1,0 +1,41 @@
+//
+// This source file is part of the CS342 2023 Utah Team Application project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import ResearchKit
+import SwiftUI
+import UIKit
+
+struct TimedWalkViewController: UIViewControllerRepresentable {
+    typealias UIViewControllerType = ORKTaskViewController
+    
+    func makeCoordinator() -> TimedWalkViewCoordinator {
+        TimedWalkViewCoordinator()
+    }
+    
+    func updateUIViewController(_ taskViewController: ORKTaskViewController, context: Context) {}
+    
+    func makeUIViewController(context: Context) -> ORKTaskViewController {
+        let timedWalkTask: ORKOrderedTask = {
+            ORKOrderedTask.timedWalk(
+                withIdentifier: "Get up and Go Task",
+                intendedUseDescription: nil,
+                distanceInMeters: 3,
+                timeLimit: 30,
+                turnAroundTimeLimit: 20,
+                includeAssistiveDeviceForm: false,
+                options: .excludeConclusion
+            )
+        }()
+        let taskViewController = ORKTaskViewController(task: timedWalkTask, taskRun: nil)
+        taskViewController.delegate = context.coordinator
+        
+        // & present the VC!
+        return taskViewController
+    }
+}

--- a/UtahModules/Sources/UtahSchedule/TimedWalk/TimedWalkViewCoordinator.swift
+++ b/UtahModules/Sources/UtahSchedule/TimedWalk/TimedWalkViewCoordinator.swift
@@ -11,8 +11,8 @@
 import Foundation
 import ResearchKit
 
-class WIQViewCoordinator: NSObject, ORKTaskViewControllerDelegate {
-    // called when the survey is completed, need to figure out how to upload data to firestore
+class TimedWalkViewCoordinator: NSObject, ORKTaskViewControllerDelegate {
+    // called when the activity is completed, need to figure out how to upload data to firestore
     public func taskViewController(
         _ taskViewController: ORKTaskViewController,
         didFinishWith reason: ORKTaskViewControllerFinishReason,

--- a/UtahModules/Sources/UtahSchedule/WIQ/WIQViewController.swift
+++ b/UtahModules/Sources/UtahSchedule/WIQ/WIQViewController.swift
@@ -6,8 +6,10 @@
 // SPDX-License-Identifier: MIT
 //
 
-import SwiftUI
+// swiftlint:disable legacy_objc_type
+
 import ResearchKit
+import SwiftUI
 import UIKit
 
 struct WIQViewController: UIViewControllerRepresentable {
@@ -20,11 +22,11 @@ struct WIQViewController: UIViewControllerRepresentable {
     func updateUIViewController(_ taskViewController: ORKTaskViewController, context: Context) {}
     
     func makeUIViewController(context: Context) -> ORKTaskViewController {
-        let sampleSurveyTask: ORKOrderedTask = {
+        let wiqSurveyTask: ORKOrderedTask = {
             var steps = [ORKStep]()
             
             let instruction = ORKInstructionStep(identifier: "WIQ")
-                    instruction.title = "Walking Impairment Questionnaire"
+                    instruction.title = "Walking Impairement Questionnaire"
                     instruction.text = "Patient Mobility Assessment"
                     
                     steps += [instruction]
@@ -38,71 +40,21 @@ struct WIQViewController: UIViewControllerRepresentable {
                     ]
                     
                     let wiqAnswerFormat = ORKAnswerFormat.choiceAnswerFormat(with: .singleChoice, textChoices: wiqChoices)
-            
-                    // Q1
-                    let wiq1 = ORKQuestionStep(
-                        identifier: "WIQ Endurance 1",
-                        title: "How difficult was it for you to:",
-                        question: "Walk indoors, such as around your home?",
-                        answer: wiqAnswerFormat
-                    )
-                    wiq1.isOptional = false
-            
-                    // Q2
-                    let wiq2 = ORKQuestionStep(
-                        identifier: "WIQ Endurance 2",
-                        title: "How difficult was it for you to:",
-                        question: "Walk 50 feet?",
-                        answer: wiqAnswerFormat
-                    )
-                    wiq2.isOptional = false
-            
-                    // Q3
-                    let wiq3 = ORKQuestionStep(
-                        identifier: "WIQ Endurance 3",
-                        title: "How difficult was it for you to:",
-                        question: "Walk 150 feet? (1/2 block)",
-                        answer: wiqAnswerFormat
-                    )
-                    wiq3.isOptional = false
-            
-                    // Q4
-                    let wiq4 = ORKQuestionStep(
-                        identifier: "WIQ Endurance 4",
-                        title: "How difficult was it for you to:",
-                        question: "Walk 300 feet? 1 block?",
-                        answer: wiqAnswerFormat
-                    )
-                    wiq4.isOptional = false
-            
-                    // Q5
-                    let wiq5 = ORKQuestionStep(
-                        identifier: "WIQ Endurance 5",
-                        title: "How difficult was it for you to:",
-                        question: "Walk 600 feet? 2 blocks?",
-                        answer: wiqAnswerFormat
-                    )
-                    wiq5.isOptional = false
-            
-                    // Q6
-                    let wiq6 = ORKQuestionStep(
-                        identifier: "WIQ Endurance 6",
-                        title: "How difficult was it for you to:",
-                        question: "Walk 900 feet? 3 blocks?",
-                        answer: wiqAnswerFormat
-                    )
-                    wiq6.isOptional = false
-            
-                    // Q7
-                    let wiq7 = ORKQuestionStep(
-                        identifier: "WIQ Endurance 7",
-                        title: "How difficult was it for you to:",
-                        question: "Walk 1500 feet? 5 blocks?",
-                        answer: wiqAnswerFormat
-                    )
-                    wiq7.isOptional = false
                     
-                    steps += [wiq1, wiq2, wiq3, wiq4, wiq5, wiq6, wiq7]
+                    let questions = [
+                        "Walk indoors, such as around your home?", "Walk 50 feet?", "Walk 150 feet? (1/2 block)",
+                        "Walk 300 feet? 1 block?", "Walk 600 feet? 2 blocks?", "Walk 900 feet? 3 blocks?", "Walk 1500 feet? 5 blocks?"
+                    ]
+                    for (idx, question) in questions.enumerated() {
+                        let wiq = ORKQuestionStep(
+                            identifier: String(format: "WIQ Endurance %d", idx + 1),
+                            title: "How difficult was it for you to:",
+                            question: question,
+                            answer: wiqAnswerFormat
+                        )
+                        wiq.isOptional = false
+                        steps += [wiq]
+                    }
                     
                     // SUMMARY
                     let summaryStep = ORKCompletionStep(identifier: "SummaryStep")
@@ -113,11 +65,10 @@ struct WIQViewController: UIViewControllerRepresentable {
                     return ORKOrderedTask(identifier: "WIQ", steps: steps)
         }()
         
-        let taskViewController = ORKTaskViewController(task: sampleSurveyTask, taskRun: nil)
+        let taskViewController = ORKTaskViewController(task: wiqSurveyTask, taskRun: nil)
         taskViewController.delegate = context.coordinator
         
         // & present the VC!
         return taskViewController
     }
-    
 }

--- a/UtahModules/Sources/UtahSchedule/WIQ/WIQViewController.swift
+++ b/UtahModules/Sources/UtahSchedule/WIQ/WIQViewController.swift
@@ -7,11 +7,10 @@
 //
 
 import SwiftUI
-import UIKit
 import ResearchKit
+import UIKit
 
 struct WIQViewController: UIViewControllerRepresentable {
-    
     typealias UIViewControllerType = ORKTaskViewController
     
     func makeCoordinator() -> WIQViewCoordinator {
@@ -21,7 +20,6 @@ struct WIQViewController: UIViewControllerRepresentable {
     func updateUIViewController(_ taskViewController: ORKTaskViewController, context: Context) {}
     
     func makeUIViewController(context: Context) -> ORKTaskViewController {
-
         let sampleSurveyTask: ORKOrderedTask = {
             var steps = [ORKStep]()
             
@@ -31,7 +29,6 @@ struct WIQViewController: UIViewControllerRepresentable {
                     
                     steps += [instruction]
                 
-                    //1: wiq form
                     let wiqChoices = [
                         ORKTextChoice(text: "No Difficulty", value: 0 as NSNumber),
                         ORKTextChoice(text: "Slight Difficulty", value: 1 as NSNumber),
@@ -43,43 +40,77 @@ struct WIQViewController: UIViewControllerRepresentable {
                     let wiqAnswerFormat = ORKAnswerFormat.choiceAnswerFormat(with: .singleChoice, textChoices: wiqChoices)
             
                     // Q1
-                    let wiq1 = ORKQuestionStep(identifier: "WIQ Endurance 1", title: "How difficult was it for you to:", question: "Walk indoors, such as around your home?", answer: wiqAnswerFormat)
+                    let wiq1 = ORKQuestionStep(
+                        identifier: "WIQ Endurance 1",
+                        title: "How difficult was it for you to:",
+                        question: "Walk indoors, such as around your home?",
+                        answer: wiqAnswerFormat
+                    )
                     wiq1.isOptional = false
             
                     // Q2
-                    let wiq2 = ORKQuestionStep(identifier: "WIQ Endurance 2", title: "How difficult was it for you to:", question: "Walk 50 feet?", answer: wiqAnswerFormat)
+                    let wiq2 = ORKQuestionStep(
+                        identifier: "WIQ Endurance 2",
+                        title: "How difficult was it for you to:",
+                        question: "Walk 50 feet?",
+                        answer: wiqAnswerFormat
+                    )
                     wiq2.isOptional = false
             
                     // Q3
-                    let wiq3 = ORKQuestionStep(identifier: "WIQ Endurance 3", title: "How difficult was it for you to:", question: "Walk 150 feet? (1/2 block)", answer: wiqAnswerFormat)
+                    let wiq3 = ORKQuestionStep(
+                        identifier: "WIQ Endurance 3",
+                        title: "How difficult was it for you to:",
+                        question: "Walk 150 feet? (1/2 block)",
+                        answer: wiqAnswerFormat
+                    )
                     wiq3.isOptional = false
             
                     // Q4
-                    let wiq4 = ORKQuestionStep(identifier: "WIQ Endurance 4", title: "How difficult was it for you to:", question: "Walk 300 feet? 1 block?", answer: wiqAnswerFormat)
+                    let wiq4 = ORKQuestionStep(
+                        identifier: "WIQ Endurance 4",
+                        title: "How difficult was it for you to:",
+                        question: "Walk 300 feet? 1 block?",
+                        answer: wiqAnswerFormat
+                    )
                     wiq4.isOptional = false
             
                     // Q5
-                    let wiq5 = ORKQuestionStep(identifier: "WIQ Endurance 5", title: "How difficult was it for you to:", question: "Walk 600 feet? 2 blocks?", answer: wiqAnswerFormat)
+                    let wiq5 = ORKQuestionStep(
+                        identifier: "WIQ Endurance 5",
+                        title: "How difficult was it for you to:",
+                        question: "Walk 600 feet? 2 blocks?",
+                        answer: wiqAnswerFormat
+                    )
                     wiq5.isOptional = false
             
                     // Q6
-                    let wiq6 = ORKQuestionStep(identifier: "WIQ Endurance 6", title: "How difficult was it for you to:", question: "Walk 900 feet? 3 blocks?", answer: wiqAnswerFormat)
+                    let wiq6 = ORKQuestionStep(
+                        identifier: "WIQ Endurance 6",
+                        title: "How difficult was it for you to:",
+                        question: "Walk 900 feet? 3 blocks?",
+                        answer: wiqAnswerFormat
+                    )
                     wiq6.isOptional = false
             
                     // Q7
-                    let wiq7 = ORKQuestionStep(identifier: "WIQ Endurance 7", title: "How difficult was it for you to:", question: "Walk 1500 feet? 5 blocks?", answer: wiqAnswerFormat)
+                    let wiq7 = ORKQuestionStep(
+                        identifier: "WIQ Endurance 7",
+                        title: "How difficult was it for you to:",
+                        question: "Walk 1500 feet? 5 blocks?",
+                        answer: wiqAnswerFormat
+                    )
                     wiq7.isOptional = false
                     
                     steps += [wiq1, wiq2, wiq3, wiq4, wiq5, wiq6, wiq7]
-
-                    //6: Completion
                     
-                    let summary = ORKCompletionStep(identifier:"Summary")
-                    summary.title = "Thank you."
-                    summary.text = "We appreciate your input."
-                    steps += [summary]
+                    // SUMMARY
+                    let summaryStep = ORKCompletionStep(identifier: "SummaryStep")
+                    summaryStep.title = "Thank you."
+                    summaryStep.text = "We appreciate your time."
+                    steps += [summaryStep]
                     
-                    return ORKNavigableOrderedTask(identifier: "WIQTask", steps: steps)
+                    return ORKOrderedTask(identifier: "WIQ", steps: steps)
         }()
         
         let taskViewController = ORKTaskViewController(task: sampleSurveyTask, taskRun: nil)

--- a/UtahModules/Sources/UtahSchedule/WIQ/WIQViewController.swift
+++ b/UtahModules/Sources/UtahSchedule/WIQ/WIQViewController.swift
@@ -1,0 +1,92 @@
+//
+// This source file is part of the CS342 2023 Utah Team Application project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+import UIKit
+import ResearchKit
+
+struct WIQViewController: UIViewControllerRepresentable {
+    
+    typealias UIViewControllerType = ORKTaskViewController
+    
+    func makeCoordinator() -> WIQViewCoordinator {
+        WIQViewCoordinator()
+    }
+    
+    func updateUIViewController(_ taskViewController: ORKTaskViewController, context: Context) {}
+    
+    func makeUIViewController(context: Context) -> ORKTaskViewController {
+
+        let sampleSurveyTask: ORKOrderedTask = {
+            var steps = [ORKStep]()
+            
+            let instruction = ORKInstructionStep(identifier: "WIQ")
+                    instruction.title = "Walking Impairment Questionnaire"
+                    instruction.text = "Patient Mobility Assessment"
+                    
+                    steps += [instruction]
+                
+                    //1: wiq form
+                    let wiqChoices = [
+                        ORKTextChoice(text: "No Difficulty", value: 0 as NSNumber),
+                        ORKTextChoice(text: "Slight Difficulty", value: 1 as NSNumber),
+                        ORKTextChoice(text: "Some Difficulty", value: 2 as NSNumber),
+                        ORKTextChoice(text: "Much Difficulty", value: 3 as NSNumber),
+                        ORKTextChoice(text: "Unable to Do", value: 4 as NSNumber)
+                    ]
+                    
+                    let wiqAnswerFormat = ORKAnswerFormat.choiceAnswerFormat(with: .singleChoice, textChoices: wiqChoices)
+            
+                    // Q1
+                    let wiq1 = ORKQuestionStep(identifier: "WIQ Endurance 1", title: "How difficult was it for you to:", question: "Walk indoors, such as around your home?", answer: wiqAnswerFormat)
+                    wiq1.isOptional = false
+            
+                    // Q2
+                    let wiq2 = ORKQuestionStep(identifier: "WIQ Endurance 2", title: "How difficult was it for you to:", question: "Walk 50 feet?", answer: wiqAnswerFormat)
+                    wiq2.isOptional = false
+            
+                    // Q3
+                    let wiq3 = ORKQuestionStep(identifier: "WIQ Endurance 3", title: "How difficult was it for you to:", question: "Walk 150 feet? (1/2 block)", answer: wiqAnswerFormat)
+                    wiq3.isOptional = false
+            
+                    // Q4
+                    let wiq4 = ORKQuestionStep(identifier: "WIQ Endurance 4", title: "How difficult was it for you to:", question: "Walk 300 feet? 1 block?", answer: wiqAnswerFormat)
+                    wiq4.isOptional = false
+            
+                    // Q5
+                    let wiq5 = ORKQuestionStep(identifier: "WIQ Endurance 5", title: "How difficult was it for you to:", question: "Walk 600 feet? 2 blocks?", answer: wiqAnswerFormat)
+                    wiq5.isOptional = false
+            
+                    // Q6
+                    let wiq6 = ORKQuestionStep(identifier: "WIQ Endurance 6", title: "How difficult was it for you to:", question: "Walk 900 feet? 3 blocks?", answer: wiqAnswerFormat)
+                    wiq6.isOptional = false
+            
+                    // Q7
+                    let wiq7 = ORKQuestionStep(identifier: "WIQ Endurance 7", title: "How difficult was it for you to:", question: "Walk 1500 feet? 5 blocks?", answer: wiqAnswerFormat)
+                    wiq7.isOptional = false
+                    
+                    steps += [wiq1, wiq2, wiq3, wiq4, wiq5, wiq6, wiq7]
+
+                    //6: Completion
+                    
+                    let summary = ORKCompletionStep(identifier:"Summary")
+                    summary.title = "Thank you."
+                    summary.text = "We appreciate your input."
+                    steps += [summary]
+                    
+                    return ORKNavigableOrderedTask(identifier: "WIQTask", steps: steps)
+        }()
+        
+        let taskViewController = ORKTaskViewController(task: sampleSurveyTask, taskRun: nil)
+        taskViewController.delegate = context.coordinator
+        
+        // & present the VC!
+        return taskViewController
+    }
+    
+}

--- a/UtahModules/Sources/UtahSchedule/WIQ/WIQViewCoordinator.swift
+++ b/UtahModules/Sources/UtahSchedule/WIQ/WIQViewCoordinator.swift
@@ -15,5 +15,3 @@ class WIQViewCoordinator: NSObject, ORKTaskViewControllerDelegate {
         taskViewController.dismiss(animated: true, completion: nil)
     }
 }
-
-

--- a/UtahModules/Sources/UtahSchedule/WIQ/WIQViewCoordinator.swift
+++ b/UtahModules/Sources/UtahSchedule/WIQ/WIQViewCoordinator.swift
@@ -1,0 +1,19 @@
+//
+// This source file is part of the CS342 2023 Utah Team Application project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import Foundation
+import ResearchKit
+
+class WIQViewCoordinator: NSObject, ORKTaskViewControllerDelegate {
+    // called when the survey is completed, need to figure out how to upload data to firestore
+    public func taskViewController(_ taskViewController: ORKTaskViewController, didFinishWith reason: ORKTaskViewControllerFinishReason, error: Error?) {
+        taskViewController.dismiss(animated: true, completion: nil)
+    }
+}
+
+

--- a/UtahModules/Sources/UtahSchedule/WIQ/WIQViewCoordinator.swift
+++ b/UtahModules/Sources/UtahSchedule/WIQ/WIQViewCoordinator.swift
@@ -11,7 +11,11 @@ import ResearchKit
 
 class WIQViewCoordinator: NSObject, ORKTaskViewControllerDelegate {
     // called when the survey is completed, need to figure out how to upload data to firestore
-    public func taskViewController(_ taskViewController: ORKTaskViewController, didFinishWith reason: ORKTaskViewControllerFinishReason, error: Error?) {
+    public func taskViewController(
+        _ taskViewController: ORKTaskViewController,
+        didFinishWith reason: ORKTaskViewControllerFinishReason,
+        error: Error?
+    ) {
         taskViewController.dismiss(animated: true, completion: nil)
     }
 }

--- a/UtahUITests/EdmontonTests.swift
+++ b/UtahUITests/EdmontonTests.swift
@@ -1,0 +1,57 @@
+//
+// This source file is part of the CS342 2023 Utah Team Application project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import XCTest
+
+
+class EdmontonTests: XCTestCase {
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        
+        continueAfterFailure = false
+        
+        let app = XCUIApplication()
+        app.launchArguments = ["--skipOnboarding"]
+        app.launch()
+    }
+    
+    
+    func testEdmonton() throws {
+        let app = XCUIApplication()
+        
+        XCTAssertTrue(app.tabBars["Tab Bar"].buttons["Questions"].waitForExistence(timeout: 0.5))
+        app.tabBars["Tab Bar"].buttons["Questions"].tap()
+
+        XCTAssertTrue(app.buttons["Edmonton Frail Scale"].waitForExistence(timeout: 0.5))
+        app.buttons["Edmonton Frail Scale"].tap()
+        XCTAssertTrue(app.staticTexts["Patient Questionnaire"].waitForExistence(timeout: 0.5))
+        XCTAssertTrue(app.buttons["Next"].waitForExistence(timeout: 0.5))
+        app.buttons["Next"].tap()
+        XCTAssertTrue(app.staticTexts["Draw a clock"].waitForExistence(timeout: 0.5))
+        XCTAssertTrue(app.buttons["Get Started"].waitForExistence(timeout: 0.5))
+        app.buttons["Get Started"].tap()
+        
+        XCTAssertTrue(app.buttons["Skip"].waitForExistence(timeout: 0.5))
+        app.buttons["Skip"].tap()
+        
+        // Go through each question
+        let answers = ["0", "Good", "5-8", "Sometimes", "Yes", "No", "Yes", "No", "No"]
+        for answer in answers {
+            XCTAssertTrue(app.tables.staticTexts[answer].waitForExistence(timeout: 0.5))
+            app.tables.staticTexts[answer].tap()
+            XCTAssertTrue(app.tables.buttons["Next"].waitForExistence(timeout: 0.5))
+            app.tables.buttons["Next"].tap()
+        }
+        
+        XCTAssertTrue(app.tables.staticTexts["Thank you."].waitForExistence(timeout: 0.5))
+        XCTAssertTrue(app.tables.buttons["Done"].waitForExistence(timeout: 0.5))
+        app.tables.buttons["Done"].tap()
+        
+        
+    }
+}

--- a/UtahUITests/EdmontonTests.swift
+++ b/UtahUITests/EdmontonTests.swift
@@ -8,7 +8,6 @@
 
 import XCTest
 
-
 class EdmontonTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -19,7 +18,6 @@ class EdmontonTests: XCTestCase {
         app.launchArguments = ["--skipOnboarding"]
         app.launch()
     }
-    
     
     func testEdmonton() throws {
         let app = XCUIApplication()
@@ -51,7 +49,5 @@ class EdmontonTests: XCTestCase {
         XCTAssertTrue(app.tables.staticTexts["Thank you."].waitForExistence(timeout: 0.5))
         XCTAssertTrue(app.tables.buttons["Done"].waitForExistence(timeout: 0.5))
         app.tables.buttons["Done"].tap()
-        
-        
     }
 }

--- a/UtahUITests/EdmontonTests.swift
+++ b/UtahUITests/EdmontonTests.swift
@@ -46,8 +46,8 @@ class EdmontonTests: XCTestCase {
             app.tables.buttons["Next"].tap()
         }
         
-        XCTAssertTrue(app.tables.staticTexts["Thank you."].waitForExistence(timeout: 0.5))
-        XCTAssertTrue(app.tables.buttons["Done"].waitForExistence(timeout: 0.5))
-        app.tables.buttons["Done"].tap()
+        XCTAssertTrue(app.staticTexts["Thank you."].waitForExistence(timeout: 0.5))
+        XCTAssertTrue(app.buttons["Done"].waitForExistence(timeout: 0.5))
+        app.buttons["Done"].tap()
     }
 }

--- a/UtahUITests/GetUpAndGoTests.swift
+++ b/UtahUITests/GetUpAndGoTests.swift
@@ -32,4 +32,17 @@ class GetUpAndGoTests: XCTestCase {
         XCTAssertTrue(app.staticTexts["Do not do this alone. Please have someone by you to help you if necessary."].waitForExistence(timeout: 0.5))
         XCTAssertTrue(app.buttons["Start"].waitForExistence(timeout: 0.5))
     }
+    
+    func testTimedWalk() throws {
+        let app = XCUIApplication()
+        
+        XCTAssertTrue(app.tabBars["Tab Bar"].buttons["Questions"].waitForExistence(timeout: 0.5))
+        app.tabBars["Tab Bar"].buttons["Questions"].tap()
+
+        XCTAssertTrue(app.buttons["Timed Walk (ResearchKit)"].waitForExistence(timeout: 0.5))
+        app.buttons["Timed Walk (ResearchKit)"].tap()
+        XCTAssertTrue(app.staticTexts["Timed Walk"].waitForExistence(timeout: 0.5))
+        XCTAssertTrue(app.buttons["Next"].waitForExistence(timeout: 0.5))
+        app.buttons["Next"].tap()
+    }
 }

--- a/UtahUITests/WIQTests.swift
+++ b/UtahUITests/WIQTests.swift
@@ -27,17 +27,30 @@ class WIQTests: XCTestCase {
 
         XCTAssertTrue(app.buttons["Walking Impairement Questionnaire"].waitForExistence(timeout: 0.5))
         app.buttons["Walking Impairement Questionnaire"].tap()
-        XCTAssertTrue(app.staticTexts["Walking Impairment Questionnaire"].waitForExistence(timeout: 0.5))
+        XCTAssertTrue(app.staticTexts["Walking Impairement Questionnaire"].waitForExistence(timeout: 0.5))
+        XCTAssertTrue(app.staticTexts["Patient Mobility Assessment"].waitForExistence(timeout: 0.5))
         XCTAssertTrue(app.buttons["Get Started"].waitForExistence(timeout: 0.5))
         app.buttons["Get Started"].tap()
         
         // Go through each question
-        let answers = ["No Difficulty", "Slight Difficulty", "Some Difficulty", "Much Difficulty", "Unable to Do", "Slight Difficulty", "No Difficulty"]
+        let answers = [
+            "No Difficulty",
+            "Slight Difficulty",
+            "Some Difficulty",
+            "Much Difficulty",
+            "Unable to Do",
+            "Slight Difficulty",
+            "No Difficulty"
+        ]
         for answer in answers {
             XCTAssertTrue(app.tables.staticTexts[answer].waitForExistence(timeout: 0.5))
             app.tables.staticTexts[answer].tap()
             XCTAssertTrue(app.tables.buttons["Next"].waitForExistence(timeout: 0.5))
             app.tables.buttons["Next"].tap()
         }
+        
+        XCTAssertTrue(app.staticTexts["Thank you."].waitForExistence(timeout: 0.5))
+        XCTAssertTrue(app.buttons["Done"].waitForExistence(timeout: 0.5))
+        app.buttons["Done"].tap()
     }
 }

--- a/UtahUITests/WIQTests.swift
+++ b/UtahUITests/WIQTests.swift
@@ -1,0 +1,51 @@
+//
+// This source file is part of the CS342 2023 Utah Team Application project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import XCTest
+
+
+class WIQTests: XCTestCase {
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        
+        continueAfterFailure = false
+        
+        let app = XCUIApplication()
+        app.launchArguments = ["--skipOnboarding"]
+        app.launch()
+    }
+    
+    
+    func testWIQ() throws {
+        let app = XCUIApplication()
+        
+        XCTAssertTrue(app.tabBars["Tab Bar"].buttons["Questions"].waitForExistence(timeout: 0.5))
+        app.tabBars["Tab Bar"].buttons["Questions"].tap()
+
+        XCTAssertTrue(app.buttons["Walking Impairement Questionnaire"].waitForExistence(timeout: 0.5))
+        app.buttons["Walking Impairement Questionnaire"].tap()
+        XCTAssertTrue(app.staticTexts["Walking Impairment Questionnaire"].waitForExistence(timeout: 0.5))
+        XCTAssertTrue(app.buttons["Get Started"].waitForExistence(timeout: 0.5))
+        app.buttons["Get Started"].tap()
+        
+        // Go through each question
+        let answers = ["No Difficulty", "Slight Difficulty", "Some Difficulty", "Much Difficulty", "Unable to Do", "Slight Difficulty", "No Difficulty"]
+        for answer in answers {
+            XCTAssertTrue(app.tables.staticTexts[answer].waitForExistence(timeout: 0.5))
+            app.tables.staticTexts[answer].tap()
+            XCTAssertTrue(app.tables.buttons["Next"].waitForExistence(timeout: 0.5))
+            app.tables.buttons["Next"].tap()
+        }
+        
+        XCTAssertTrue(app.tables.staticTexts["Thank you."].waitForExistence(timeout: 0.5))
+        XCTAssertTrue(app.tables.buttons["Done"].waitForExistence(timeout: 0.5))
+        app.tables.buttons["Done"].tap()
+        
+        
+    }
+}

--- a/UtahUITests/WIQTests.swift
+++ b/UtahUITests/WIQTests.swift
@@ -8,7 +8,6 @@
 
 import XCTest
 
-
 class WIQTests: XCTestCase {
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -19,7 +18,6 @@ class WIQTests: XCTestCase {
         app.launchArguments = ["--skipOnboarding"]
         app.launch()
     }
-    
     
     func testWIQ() throws {
         let app = XCUIApplication()
@@ -41,11 +39,5 @@ class WIQTests: XCTestCase {
             XCTAssertTrue(app.tables.buttons["Next"].waitForExistence(timeout: 0.5))
             app.tables.buttons["Next"].tap()
         }
-        
-        XCTAssertTrue(app.tables.staticTexts["Thank you."].waitForExistence(timeout: 0.5))
-        XCTAssertTrue(app.tables.buttons["Done"].waitForExistence(timeout: 0.5))
-        app.tables.buttons["Done"].tap()
-        
-        
     }
 }


### PR DESCRIPTION
<!--

This source file is part of the Stanford CS342 - Building for Digital Health class

SPDX-FileCopyrightText: 2022 Stanford University

SPDX-License-Identifier: MIT

-->

# Inital ResearchKit Survey Implementation

## :recycle: Current situation & Problem
CardinalKit survey module is not flexible enough for the Edmonton Frail Scale

## :bulb: Proposed solution
Implement using ResearchKit

## :gear: Release Notes 
New pages in temporary buttons for now, added:
- Edmonton Frail Scale (with photo capture for Clock Test)
- Walking impairment questionnaire (requested last week by mentors)
- Time Walk (from ResearchKit) for us to test, it may be good enough for the "Get up and Go Test"

<img src="https://user-images.githubusercontent.com/43686739/219997764-118624df-005b-46fb-94b4-90a246fd5967.gif" width="300" />

<img src="https://user-images.githubusercontent.com/43686739/219998181-a88004ea-f50e-4e5e-bac9-d980bf0c8ce4.gif" width="300" />

https://user-images.githubusercontent.com/43686739/219998438-e084588b-9727-4856-b849-7792c359f614.mp4

## :heavy_plus_sign: Additional Information

Still need to:
- Test the image upload (on device)
- Test the Walk Test (on device)
- Figure out getting data to JSON -> Firestore (Vishnu is going to ask Paul how best to do this)
- Adding the walk test to the end of the Edmonton Frail Scale
- Putting the surveys inside the scheduler (provided by CardinalKit)

### Testing
Basic survey UI tested

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).

