### PR TITLE
Create User in Firestore at signup

### DIFF
--- a/Utah/UtahAppDelegate.swift
+++ b/Utah/UtahAppDelegate.swift
@@ -28,7 +28,7 @@ class UtahAppDelegate: CardinalKitAppDelegate {
     override var configuration: Configuration {
         Configuration(standard: FHIR()) {
             if !CommandLine.arguments.contains("--disableFirebase") {
-                FirebaseAccountConfiguration(emulatorSettings: (host: "localhost", port: 9099))
+                FirebaseAccountConfiguration()
                 firestore
             }
             if HKHealthStore.isHealthDataAvailable() {

--- a/UtahModules/Sources/UtahOnboardingFlow/AccountSetup/AccountSetup.swift
+++ b/UtahModules/Sources/UtahOnboardingFlow/AccountSetup/AccountSetup.swift
@@ -6,9 +6,12 @@
 // SPDX-License-Identifier: MIT
 //
 
+// swiftlint:disable line_length
 import Account
 import class FHIR.FHIR
 import FirebaseAccount
+import FirebaseAuth
+import FirebaseFirestore
 import Onboarding
 import SwiftUI
 
@@ -37,6 +40,15 @@ struct AccountSetup: View {
         )
             .onReceive(account.objectWillChange) {
                 if account.signedIn {
+                    if onboardingSteps.contains(where: { $0 == .signUp }) {
+                         if let user = Auth.auth().currentUser {
+                             let fullName = user.displayName?.components(separatedBy: " ")
+                             let firstName = fullName?[0] ?? ""
+                             let lastName = fullName?[1] ?? ""
+                             let data: [String: Any] = ["firstName": firstName, "lastName": lastName, "email": user.email ?? "", "dateJoined": Timestamp()]
+                            Firestore.firestore().collection("users").document(user.uid).setData(data)
+                        }
+                    }
                     appendNextOnboardingStep()
                     // Unfortunately, SwiftUI currently animates changes in the navigation path that do not change
                     // the current top view. Therefore we need to do the following async procedure to remove the


### PR DESCRIPTION
<!--

This source file is part of the Stanford CS342 - Building for Digital Health class

SPDX-FileCopyrightText: 2022 Stanford University

SPDX-License-Identifier: MIT


-->

# *Create User in Firestore DB at signup*

## :recycle: Current situation & Problem
we have no user info saved

## :bulb: Proposed solution
Save it

## :gear: Release Notes 
n/a

## :heavy_plus_sign: Additional Information
will add the disease on next PR

### Related PRs
n/a

### Testing
Successfully saves:
<img width="429" alt="Screenshot 2023-02-23 at 5 10 11 PM" src="https://user-images.githubusercontent.com/68484673/221067299-ac029878-21c1-4810-bbda-626c0ecb4ff1.png">

### Reviewer Nudging

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).

