### PR TITLE
Firestore Rules were broken... updated them

### DIFF
--- a/UtahModules/Sources/UtahOnboardingFlow/AccountSetup/AccountSetup.swift
+++ b/UtahModules/Sources/UtahOnboardingFlow/AccountSetup/AccountSetup.swift
@@ -47,7 +47,11 @@ struct AccountSetup: View {
                              let firstName = fullName?[0] ?? ""
                              let lastName = fullName?[1] ?? ""
                              let data: [String: Any] = ["firstName": firstName, "lastName": lastName, "email": user.email ?? "", "dateJoined": Timestamp()]
-                            Firestore.firestore().collection("users").document(user.uid).setData(data)
+                             Firestore.firestore().collection("users").document(user.uid).setData(data) { err in
+                                 if let err = err {
+                                     print("Error updating document: \(err)")
+                                 }
+                             }
                         }
                     }
                     appendNextOnboardingStep()

--- a/firestore.rules
+++ b/firestore.rules
@@ -1,7 +1,7 @@
 service cloud.firestore {
   match /databases/{database}/documents {
     // Allow only authenticated content owners access
-    match /users/{userId}/{documents=**} {
+    match /users/{userId} {
       allow read, write: if request.auth != null && request.auth.uid == userId
     }
   }


### PR DESCRIPTION
<!--

This source file is part of the Stanford CS342 - Building for Digital Health class

SPDX-FileCopyrightText: 2022 Stanford University

SPDX-License-Identifier: MIT

-->

# *Firestore Rules were broken... updated them*

## :recycle: Current situation & Problem
Didn't allow users to edit their own page

## :bulb: Proposed solution
fixed that bug

## :gear: Release Notes 

## :heavy_plus_sign: Additional Information

### Related PRs

### Testing
did it on emulator

### Reviewer Nudging

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).

