### PR TITLE
Added Consent document

### DIFF
--- a/Utah.xcodeproj/xcshareddata/xcschemes/Utah.xcscheme
+++ b/Utah.xcodeproj/xcshareddata/xcschemes/Utah.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "653A254C283387FE005D4D48"
-               BuildableName = "U-Step.app"
+               BuildableName = "Utah.app"
                BlueprintName = "Utah"
                ReferencedContainer = "container:Utah.xcodeproj">
             </BuildableReference>
@@ -71,7 +71,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "653A254C283387FE005D4D48"
-            BuildableName = "U-Step.app"
+            BuildableName = "Utah.app"
             BlueprintName = "Utah"
             ReferencedContainer = "container:Utah.xcodeproj">
          </BuildableReference>
@@ -94,7 +94,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "653A254C283387FE005D4D48"
-            BuildableName = "U-Step.app"
+            BuildableName = "Utah.app"
             BlueprintName = "Utah"
             ReferencedContainer = "container:Utah.xcodeproj">
          </BuildableReference>

--- a/UtahModules/Sources/UtahOnboardingFlow/Consent.swift
+++ b/UtahModules/Sources/UtahOnboardingFlow/Consent.swift
@@ -27,8 +27,9 @@ struct Consent: View {
             header: {
                 OnboardingTitleView(
                     title: "Consent".moduleLocalized,
-                    subtitle: "U-STEP is asking to collect and analyze your healthcare information".moduleLocalized
+                    subtitle: "CONSENT_TEXT".moduleLocalized
                 )
+                .frame(alignment: .trailing)
             },
             asyncMarkdown: {
                 consentDocument

--- a/UtahModules/Sources/UtahOnboardingFlow/Resources/en.lproj/Localizable.strings
+++ b/UtahModules/Sources/UtahOnboardingFlow/Resources/en.lproj/Localizable.strings
@@ -45,6 +45,153 @@
 // MARK: Consent
 "CONSENT_TITLE" = "Review Consent Form";
 "CONSENT_SUBTITLE" = "Review the form below and tap Agree if you’re ready to continue.";
+"CONSENT_TEXT" = "Utah Vascular Surgery PROMs & Health Maintenance Application
+
+INTRODUCTION
+You are being asked to take part this research study because you have been
+diagnosed with peripheral vascular disease (PVD). Before you decide whether you
+would like to take part, it is important for you to understand why the research is
+being done and what it will involve. Please take time to read the following
+information carefully. Ask us if there is anything that is not clear or if you would like
+more information. Take time to decide whether you want to volunteer to take part
+in this study.
+
+WHY IS THIS RESEARCH BEING DONE?
+Vascular surgery is a surgical subspecialty in which arterial and venous diseases are
+managed   by   medical   therapy,   minimally   invasive   procedures,   and   surgical
+interventions.  These procedures are undertaken to treat PVD and improve patient’s
+quality of life, pain, activity level, and preserve physical function. The purpose of
+this study is to utilize a smartphone application that will allow vascular surgeons
+and their patients to track health status and functional outcomes over time.
+
+WHO IS IN CHARGE OF THIS RESEARCH?
+This study is being conducted by Dr. Benjamin S. Brooke, MD, PhD, Chief of the
+Division of Vascular Surgery, and the research team, at the University of Utah.
+
+WHAT IS INVOLVED IN THIS RESEARCH?
+The central goal of this project is to develop a software application for your
+smartphone that can collect patient health information to help inform health
+changes for patients with PVD and their providers. The smartphone application will
+collect two different types of data:
+
+1. Patient Reported Outcome Measures (PROMs): PROMs are objective
+questionnaires that represent a patient’s self-reported health without any
+interpretation from a provider. PROMs can be used as surrogate measures for
+outcomes that are difficult for providers to see and quantify. PROMs can be
+easily administered over a smartphone application and are relatively quick
+for patients to complete.
+2. Passive activity: Passive activity, including number of steps walked, from
+patient’s smart phone or smart watch will be shared with the application.
+You will receive notification reminders within the smartphone application to re-
+complete the PROMs on a monthly basis.
+
+HOW LONG WILL I BE IN THIS RESEARCH?
+The anticipated time for your participation in this research is approximately one
+year, but may be longer if you continue to have symptoms of PVD that require
+follow-up with the vascular surgery team. Further, we encourage you to utilize the
+smartphone application for as long as you feel that it is helpful to monitor your
+health status.
+
+WHAT ARE THE POSSIBLE RISKS?
+The risks of this study are minimal. There is the potential risk of loss of
+confidentiality. Every effort will be made to keep your information confidential;
+however, this cannot be guaranteed. You may stop your participation in the
+smartphone application at any time.
+
+ARE THERE BENEFITS TO TAKING PART IN THIS RESEARCH?
+Possible benefits may include the ability to view your own health status and
+progress, as well as changes that occur over time. Knowing this valuable
+information about yourself could help facilitate discussions and healthcare decisions
+with your provider.
+
+WHAT ARE THE COSTS AND COMPENSATION?
+There are no costs to you for participation in this research. The smartphone
+application is available for free download and participation at no cost to you. There
+is no compensation for participation.
+
+WHAT ALTERNATIVES ARE THERE TO PARTICIPATION IN THIS RESEARCH?
+This is an observational research study, so your alternative to participation is not to
+participate.
+
+WHOM DO I CALL IF I HAVE QUESTIONS OR PROBLEMS?
+If you have questions, complaints or concerns about this study, you can contact the
+Principal Investigator, Dr. Benjamin S. Brooke at 801-581-8301. You may also
+contact Research Nurse, Julie Hales, at 801-587-1450.
+
+Contact the Institutional Review Board (IRB) if you have questions regarding your
+rights as a research participant. Also, contact the IRB if you have questions,
+complaints or concerns which you do not feel you can discuss with the investigator.
+The University of Utah IRB may be reached by phone at (801) 581-3655 or by e-mail
+at irb@hsc.utah.edu.
+
+Research Participant Advocate:  You may also contact the Research Participant
+Advocate (RPA) by phone at (801) 581-3803 or by email at
+participant.advocate@hsc.utah.edu.
+
+WHAT ABOUT MY RIGHTS TO DECLINE PARTICIPATION OR WITHDRAW
+FROM THIS RESEARCH?
+Research studies include only people who choose to take part.  You can tell us that
+you don’t want to be in this study.  You can start the study and then choose to stop
+the study later.  Your decision not to participate or to withdraw from the study will
+not involve any penalty or loss of benefits to which you are entitled, and will not
+affect your access to health care at The University of Utah. If you do decide to
+withdraw, we ask that you contact Dr. Benjamin Brooke and let him know that you
+are withdrawing. His contact information is:
+
+Benjamin Brooke, MD, PhD
+The University of Utah
+Division of Vascular Surgery, Dept. of Surgery
+30 North 1900 East, Room 3C344 SOM
+Salt Lake City, UT 84132
+Office Phone: (801) 581-8301
+
+WHAT PERSONAL HEALTH INFORMATION ARE YOU ASKING ME TO PROVIDE?
+The smartphone application will ask you to enter your name, phone number, and
+email address. The smartphone application will ask you to indicate whether you
+have arterial disease, venous disease, or both. We will keep all research records
+that identify you private to the extent allowed by law. Your name will not be kept
+with your responses from the PROMs nor the passive activity (i.e. number of steps
+walked). In publications, your name will be removed.
+Entering your name, phone number, and email address in to the smartphone
+application means you allow us, the researchers in this study, and others working
+with us to use some information about your health for this research study.
+This is the information we will use and include in our research records:
+- Demographic and identifying information: name, telephone number, and
+email address
+- Patient Reported Outcome Measures (PROMs) and passive activity (such as
+number of steps walked)
+
+HOW WILL WE PROTECT AND SHARE YOUR INFORMATION?
+We will do everything we can to keep your information private but we cannot
+guarantee this. Study information will be kept in a secured manner and electronic
+records will be password protected. Study information will not be stored with other
+information in your medical record. We may also need to disclose information if
+required by law.
+In order to conduct this study and make sure it is conducted as described in this
+form, the research records may be used and reviewed by others who are working
+with us on this research:
+- Members of the research team and University of Utah Health Sciences Center
+- The University of Utah Institutional Review Board (IRB), which reviews
+research involving people to make sure the study protects your rights;
+If we share your information with groups outside of University of Utah Health
+Sciences Center, we will not share your name or identifying information.  We will
+label your information with a code number, so they will not know your identity.
+
+If you do not want us to use information about your health, you should not be part
+of this research. If you choose not to participate, you can still receive health care
+services at University of Utah Health Sciences Center.
+ 
+WHAT IF I DECIDE NOT TO PARTICPATE AFTER I SIGN UP FOR THE
+SMARTPHONE APP?
+You can tell us anytime that you do not want to be in this study and do not want us
+to use your health information.  You can also tell us in writing.  If you change your
+mind, we will not be able to collect new information about you, and you will be
+withdrawn from the research study. However, we can continue to use information
+we have already started to use in our research, as needed to maintain the integrity
+of the research.
+
+This authorization does not have an expiration date.
+Thank you for your consideration to take part in this important research study";
 
 "CONSENT_LOADING_ERROR" = "Please include a markdown based document named \"ConsentDocument\" in your module Bundle.";
 


### PR DESCRIPTION
<!--

This source file is part of the Stanford CS342 - Building for Digital Health class

SPDX-FileCopyrightText: 2022 Stanford University

SPDX-License-Identifier: MIT

-->

# *Name of the PR*

## :recycle: Current situation & Problem
Consent page still had template text

## :bulb: Proposed solution
Filled in consent information

## :gear: Release Notes

## :heavy_plus_sign: Additional Information
Still need to figure out how to change font size, coloring - can't access CardinalKit itself
Also need to figure out how to change alignment (likely need to add this feature in same place as CardinalKit)

### Related PRs
Continuation of "Onboarding flow pgs 1,2"

### Testing

### Reviewer Nudging

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [ ] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).

