### PR TITLE
Create custom HTML consent view

### DIFF
--- a/Utah.xcodeproj/xcshareddata/xcschemes/Utah.xcscheme
+++ b/Utah.xcodeproj/xcshareddata/xcschemes/Utah.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "653A254C283387FE005D4D48"
-               BuildableName = "U-Step.app"
+               BuildableName = "Utah.app"
                BlueprintName = "Utah"
                ReferencedContainer = "container:Utah.xcodeproj">
             </BuildableReference>
@@ -71,7 +71,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "653A254C283387FE005D4D48"
-            BuildableName = "U-Step.app"
+            BuildableName = "Utah.app"
             BlueprintName = "Utah"
             ReferencedContainer = "container:Utah.xcodeproj">
          </BuildableReference>
@@ -94,7 +94,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "653A254C283387FE005D4D48"
-            BuildableName = "U-Step.app"
+            BuildableName = "Utah.app"
             BlueprintName = "Utah"
             ReferencedContainer = "container:Utah.xcodeproj">
          </BuildableReference>

--- a/UtahModules/Sources/UtahOnboardingFlow/Consent.swift
+++ b/UtahModules/Sources/UtahOnboardingFlow/Consent.swift
@@ -15,30 +15,35 @@ struct Consent: View {
     
     
     private var consentDocument: Data {
-        guard let path = Bundle.module.url(forResource: "ConsentDocument", withExtension: "md"),
+        guard let path = Bundle.module.url(forResource: "ConsentDocument", withExtension: "html"),
               let data = try? Data(contentsOf: path) else {
             return Data("CONSENT_LOADING_ERROR".moduleLocalized.utf8)
         }
         return data
     }
-    
+
     var body: some View {
-        ConsentView(
-            header: {
-                OnboardingTitleView(
-                    title: "Consent".moduleLocalized,
-                    subtitle: "U-STEP is asking to collect and analyze your healthcare information".moduleLocalized
-                )
-            },
-            asyncMarkdown: {
-                consentDocument
-            },
-            action: {
-                onboardingSteps.append(.conditionQuestion)
-            }
-        )
+        ScrollViewReader { _ in
+            OnboardingView(
+                contentView: {
+                    HTMLView(
+                        asyncHTML: {
+                            consentDocument
+                        }
+                    )
+                },
+                actionView: {
+                    VStack {
+                        OnboardingActionsView("I accept") {
+                            onboardingSteps.append(.conditionQuestion)
+                        }
+                        Divider()
+                    }
+                    .transition(.opacity)
+                }
+            )
+        }
     }
-    
     
     init(onboardingSteps: Binding<[OnboardingFlow.Step]>) {
         self._onboardingSteps = onboardingSteps

--- a/UtahModules/Sources/UtahOnboardingFlow/HTMLView.swift
+++ b/UtahModules/Sources/UtahOnboardingFlow/HTMLView.swift
@@ -1,0 +1,88 @@
+//
+// This source file is part of the CardinalKit open-source project
+//
+// SPDX-FileCopyrightText: 2022 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import SwiftUI
+import WebKit
+
+/// An``HTMLView`` allows the display of HTML in a web view including the addition of a header and footer view.
+///
+/// ```
+/// @State var viewState: ViewState = .idle
+///
+/// HTMLView(
+///     asyncHTML: {
+///         // Load your HTML from a remote source or disk storage ...
+///         try? await Task.sleep(for: .seconds(5))
+///         return Data("This is an <strong>HTML example</strong> taking 5 seconds to load.".utf8)
+///     },
+///     state: $viewState
+/// )
+/// ```
+private struct WebView: UIViewRepresentable {
+    var htmlContent: String
+
+    func makeUIView(context: Context) -> WKWebView {
+        WKWebView()
+    }
+
+    func updateUIView(_ uiView: WKWebView, context: Context) {
+        uiView.loadHTMLString(htmlContent, baseURL: nil)
+    }
+}
+
+
+public struct HTMLView: View {
+    private let asyncHTML: () async -> Data
+    @State private var html: Data?
+
+
+    private var htmlString: String? {
+        guard let html else {
+            return nil
+        }
+        return String(decoding: html, as: UTF8.self)
+    }
+
+    public var body: some View {
+        VStack {
+            if html == nil {
+                ProgressView()
+                    .padding()
+            } else {
+                if let htmlString {
+                    WebView(htmlContent: htmlString)
+                }
+            }
+        }
+            .task {
+                html = await asyncHTML()
+            }
+    }
+
+    /// Creates an ``HTMLView`` that displays HTML that is loaded asynchronously.
+    /// - Parameters:
+    ///   - asyncHTML: The async closure to load the html as a utf8 representation.
+    ///   - state: A `Binding` to observe the ``ViewState`` of the ``HTMLView``.
+    public init(
+        asyncHTML: @escaping () async -> Data
+    ) {
+        self.asyncHTML = asyncHTML
+    }
+
+    /// Creates an ``HTMLView`` that displays the HTML content.
+    /// - Parameters:
+    ///   - html: A `Data` instance containing the html as an utf8 representation.
+    ///   - state: A `Binding` to observe the ``ViewState`` of the ``HTMLView``.
+    public init(
+        html: Data
+    ) {
+        self.init(
+            asyncHTML: { html }
+        )
+    }
+}

--- a/UtahModules/Sources/UtahOnboardingFlow/OnboardingFlow.swift
+++ b/UtahModules/Sources/UtahOnboardingFlow/OnboardingFlow.swift
@@ -31,7 +31,8 @@ public struct OnboardingFlow: View {
                 .navigationDestination(for: Step.self) { onboardingStep in
                     switch onboardingStep {
                     case .accountSetup:
-                        AccountSetup(onboardingSteps: $onboardingSteps)
+                        Consent(onboardingSteps: $onboardingSteps)
+                        // AccountSetup(onboardingSteps: $onboardingSteps)
                     case .login:
                         UtahLogin()
                     case .signUp:

--- a/UtahModules/Sources/UtahOnboardingFlow/Resources/ConsentDocument.html
+++ b/UtahModules/Sources/UtahOnboardingFlow/Resources/ConsentDocument.html
@@ -18,11 +18,160 @@ body {
 <head>
 
 <body>
-<h1>Consent Document</h1>
+    <center>
+        <h1>Consent Form</h1>
+        <p>U-STEP is asking to collect and analyze your healthcare information</p>
+    </center>
+    
+<br>
 
 <p>
-This is the content of the consent document.
+You are being asked to take part this research study because you have been diagnosed with peripheral vascular disease (PVD). Before you decide whether you would like to take part, it is important for you to understand why the research is being done and what it will involve. Please take time to read the following information carefully. Ask us if there is anything that is not clear or if you would like more information. Take time to decide whether you want to volunteer to take part in this study.
 </p>
+
+<h3>WHY IS THIS RESEARCH BEING DONE?</h3>
+
+<p>
+Vascular surgery is a surgical subspecialty in which arterial and venous diseases are managed by medical therapy, minimally invasive procedures, and surgical interventions. These procedures are undertaken to treat PVD and improve patient’s quality of life, pain, activity level, and preserve physical function. The purpose of this study is to utilize a smartphone application that will allow vascular surgeons and their patients to track health status and functional outcomes over time.
+</p>
+
+<h3>WHO IS IN CHARGE OF THIS RESEARCH?</h3>
+
+<p>
+This study is being conducted by Dr. Benjamin S. Brooke, MD, PhD, Chief of the Division of Vascular Surgery, and the research team, at the University of Utah.
+</p>
+
+<h3>WHAT IS INVOLVED IN THIS RESEARCH?</h3>
+
+<p>
+The central goal of this project is to develop a software application for your smartphone that can collect patient health information to help inform health changes for patients with PVD and their providers. The smartphone application will collect two different types of data:
+</p>
+
+<ol>
+  <li><u>Patient Reported Outcome Measures (PROMs)</u>: PROMs are objective questionnaires that represent a patient’s self-reported health without any interpretation from a provider. PROMs can be used as surrogate measures for outcomes that are difficult for providers to see and quantify. PROMs can be easily administered over a smartphone application and are relatively quick for patients to complete.</li>
+  <li><u>Passive activity</u>: Passive activity, including number of steps walked, from patient’s smart phone or smart watch will be shared with the application.</li>
+</ol>
+
+<p>
+You will receive notification reminders within the smartphone application to re-complete the PROMs on a monthly basis.
+</p>
+
+<h3>HOW LONG WILL I BE IN THIS RESEARCH?</h3>
+
+<p>
+The anticipated time for your participation in this research is approximately one year, but may be longer if you continue to have symptoms of PVD that require follow-up with the vascular surgery team. Further, we encourage you to utilize the smartphone application for as long as you feel that it is helpful to monitor your health status.
+</p>
+
+<h3>WHAT ARE THE POSSIBLE RISKS?</h3>
+
+<p>
+The risks of this study are minimal. There is the potential risk of loss of confidentiality. Every effort will be made to keep your information confidential; however, this cannot be guaranteed. You may stop your participation in the smartphone application at any time.
+</p>
+
+<h3>ARE THERE BENEFITS TO TAKING PART IN THIS RESEARCH?</h3>
+
+<p>
+Possible benefits may include the ability to view your own health status and progress, as well as changes that occur over time. Knowing this valuable information about yourself could help facilitate discussions and healthcare decisions with your provider.
+</p>
+
+<h3>WHAT ARE THE COSTS AND COMPENSATION?</h3>
+
+<p>
+There are no costs to you for participation in this research. The smartphone application is available for free download and participation at no cost to you. There is no compensation for participation.
+</p>
+
+<h3>WHAT ALTERNATIVES ARE THERE TO PARTICIPATION IN THIS RESEARCH?</h3>
+
+<p>
+This is an observational research study, so your alternative to participation is not to participate.
+</p>
+
+<h3>
+WHOM DO I CALL IF I HAVE QUESTIONS OR PROBLEMS?
+</h3>
+
+<p>
+If you have questions, complaints or concerns about this study, you can contact the Principal Investigator, Dr. Benjamin S. Brooke at <a href="tel:8015818301">(801) 581-8301</a>. You may also contact Research Nurse, Julie Hales, at <a href="tel:8015871450">(801) 587-1450</a>.
+</p>
+
+<p>
+Contact the Institutional Review Board (IRB) if you have questions regarding your rights as a research participant. Also, contact the IRB if you have questions, complaints or concerns which you do not feel you can discuss with the investigator. The University of Utah IRB may be reached by phone at <a href="tel:8015813655">(801) 581-3655</a> or by e-mail at <a href="mailto:irb@hsc.utah.edu">irb@hsc.utah.edu</a>.
+</p>
+
+<p>
+Research Participant Advocate: You may also contact the Research Participant Advocate (RPA) by phone at <a href="tel:8015813803">(801) 581-3803</a> or by email at <a href="mailto:participant.advocate@hsc.utah.edu">participant.advocate@hsc.utah.edu</a>.
+</p>
+
+<h3>WHAT ABOUT MY RIGHTS TO DECLINE PARTICIPATION OR WITHDRAW FROM THIS RESEARCH?</h3>
+
+<p>
+Research studies include only people who choose to take part. You can tell us that you don’t want to be in this study. You can start the study and then choose to stop the study later. Your decision not to participate or to withdraw from the study will not involve any penalty or loss of benefits to which you are entitled, and will not affect your access to health care at The University of Utah. If you do decide to withdraw, we ask that you contact Dr. Benjamin Brooke and let him know that you are withdrawing. His contact information is:
+</p>
+
+<span>Benjamin Brooke, MD, PhD</><br>
+<span>The University of Utah</><br>
+<span>Division of Vascular Surgery, Dept. of Surgery</><br>
+<span>30 North 1900 East, Room 3C344 SOM</><br>
+<span>Salt Lake City, UT 84132</><br>
+<span>Office Phone: <a href="tel:8015818301">(801) 581-8301</a></>
+
+<h3>WHAT PERSONAL HEALTH INFORMATION ARE YOU ASKING ME TO PROVIDE?</h3>
+
+<p>
+The smartphone application will ask you to enter your name, phone number, and email address. The smartphone application will ask you to indicate whether you have arterial disease, venous disease, or both. We will keep all research records that identify you private to the extent allowed by law. Your name will not be kept with your responses from the PROMs nor the passive activity (i.e. number of steps walked). In publications, your name will be removed.
+</p>
+
+<p>
+Entering your name, phone number, and email address in to the smartphone application means you allow us, the researchers in this study, and others working with us to use some information about your health for this research study.
+</p>
+  
+<p>
+This is the information we will use and include in our research records:
+</p>
+
+<ul>
+    <li>Demographic and identifying information: name, telephone number, and email address</li>
+    <li>Patient Reported Outcome Measures (PROMs) and passive activity (such as number of steps walked)</li>
+</ul>
+
+<h3>HOW WILL WE PROTECT AND SHARE YOUR INFORMATION?</h3>
+
+<p>
+We will do everything we can to keep your information private but we cannot guarantee this. Study information will be kept in a secured manner and electronic records will be password protected. Study information will not be stored with other information in your medical record. We may also need to disclose information if required by law.
+</p>
+
+<p>
+In order to conduct this study and make sure it is conducted as described in this form, the research records may be used and reviewed by others who are working with us on this research:
+</p>
+
+<ul>
+    <li>Members of the research team and University of Utah Health Sciences Center</li>
+    <li>The University of Utah Institutional Review Board (IRB), which reviews research involving people to make sure the study protects your rights;</li>
+</ul>
+
+<p>
+If we share your information with groups outside of University of Utah Health Sciences Center, we will not share your name or identifying information.  We will label your information with a code number, so they will not know your identity.
+</p>
+
+<p>
+If you do not want us to use information about your health, you should not be part of this research. If you choose not to participate, you can still receive health care services at University of Utah Health Sciences Center.
+</p>
+
+<h3>WHAT IF I DECIDE NOT TO PARTICIPATE AFTER I SIGN UP FOR THE SMARTPHONE APP?</h3>
+
+<p>
+You can tell us anytime that you do not want to be in this study and do not want us to use your health information. You can also tell us in writing. If you change your mind, we will not be able to collect new information about you, and you will be withdrawn from the research study. However, we can continue to use information we have already started to use in our research, as needed to maintain the integrity of the research.
+</p>
+
+<p>
+This authorization does not have an expiration date.
+</p>
+
+<p>
+Thank you for your consideration to take part in this important research study.
+</p>
+
+
 
 </body>
 

--- a/UtahModules/Sources/UtahOnboardingFlow/Resources/ConsentDocument.html
+++ b/UtahModules/Sources/UtahOnboardingFlow/Resources/ConsentDocument.html
@@ -1,0 +1,21 @@
+<html>
+
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
+<style>
+body {
+  font-family: Arial, sans-serif;
+}
+</style>
+<head>
+
+<body>
+<h1>Consent Document</h1>
+
+<p>
+This is the content of the consent document.
+</p>
+
+</body>
+
+</html>

--- a/UtahModules/Sources/UtahOnboardingFlow/Resources/ConsentDocument.html
+++ b/UtahModules/Sources/UtahOnboardingFlow/Resources/ConsentDocument.html
@@ -1,3 +1,11 @@
+<!--
+This source file is part of the CS342 2023 Utah Team Application project
+
+SPDX-FileCopyrightText: 2023 Stanford University
+
+SPDX-License-Identifier: MIT
+-->
+
 <html>
 
 <head>

--- a/UtahModules/Sources/UtahOnboardingFlow/Resources/en.lproj/Localizable.strings
+++ b/UtahModules/Sources/UtahOnboardingFlow/Resources/en.lproj/Localizable.strings
@@ -48,10 +48,9 @@
 
 "CONSENT_LOADING_ERROR" = "Please include a markdown based document named \"ConsentDocument\" in your module Bundle.";
 
-
 // MARK: Account
 "ACCOUNT_TITLE" = "Your Account";
-"ACCOUNT_SUBTITLE" = "The PAWS Application demonstrates the usage of the Firebase Account Module.";
+"ACCOUNT_SUBTITLE" = "";
 "ACCOUNT_SETUP_DESCRIPTION" = "The login and sign up buttons use the Account Login and SignUp views.";
 "ACCOUNT_SIGNED_IN_DESCRIPTION" = "You are successfully signed in with the following account:";
 "ACCOUNT_NEXT" = "Next";
@@ -61,10 +60,10 @@
 "USER_VIEW_LOADING" = "Loading user information ...";
 
 "LOGIN_TITLE" = "Login";
-"LOGIN_SUBTITLE" = "The PAWS Application demonstrates the usage of the Firebase Account Module to enable different authentication services, including an email and password-based login.";
+"LOGIN_SUBTITLE" = "Log in to U-STEP";
 
 "SIGN_UP_TITLE" = "Sign Up";
-"SIGN_UP_SUBTITLE" = "The PAWS Application demonstrates the usage of the Firebase Account Module to enable different authentication services, including an email and password-based sign-up.";
+"SIGN_UP_SUBTITLE" = "Sign up for U-STEP";
 
 
 // MARK: HealthKit

--- a/UtahModules/Sources/UtahSchedule/WIQ/WIQViewController.swift
+++ b/UtahModules/Sources/UtahSchedule/WIQ/WIQViewController.swift
@@ -6,7 +6,6 @@
 // SPDX-License-Identifier: MIT
 //
 
-// swiftlint:disable closure_body_length
 // swiftlint:disable line_length
 
 import ResearchKit

--- a/UtahModules/Sources/UtahSchedule/WIQ/WIQViewController.swift
+++ b/UtahModules/Sources/UtahSchedule/WIQ/WIQViewController.swift
@@ -6,6 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
+// swiftlint:disable closure_body_length
 // swiftlint:disable line_length
 
 import ResearchKit


### PR DESCRIPTION
<!--

This source file is part of the Stanford CS342 - Building for Digital Health class

SPDX-FileCopyrightText: 2022 Stanford University

SPDX-License-Identifier: MIT

-->

# Create custom HTML consent view

## :recycle: Current situation & Problem
This project requires additional styling that Markdown cannot support, and also needs to customize the consent view such that the name and signature view do not appear.

## :bulb: Proposed solution
Creates a new `HTMLView` in `UtahOnboardingFlow` for displaying HTML documents, and uses it to create a custom consent view that reads in the `ConsentDocument.html` file located in the `Resources` folder.

![ezgif-1-aaafd276f9](https://user-images.githubusercontent.com/43686739/221715426-f4b17c23-2c8f-4721-9892-0cfd42a52e3b.gif)

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).

