### PR TITLE
Fix Onboarding flow for 3rd case

### DIFF
--- a/Utah.xcodeproj/project.pbxproj
+++ b/Utah.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		23B0449B299DB70A008CD957 /* GetUpAndGoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23B0449A299DB70A008CD957 /* GetUpAndGoTests.swift */; };
 		23DA6D2D29AD46A5007A6B73 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = 23DA6D2C29AD46A5007A6B73 /* FirebaseAuth */; };
+		23DA6D3129ADC1E7007A6B73 /* UtahAppSetup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 23DA6D3029ADC1E7007A6B73 /* UtahAppSetup.swift */; };
 		27A7B3E829A7B2C8000B32B4 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 27A7B3E729A7B2C8000B32B4 /* GoogleService-Info.plist */; };
 		2F49B7762980407C00BCB272 /* CardinalKit in Frameworks */ = {isa = PBXBuildFile; productRef = 2F49B7752980407B00BCB272 /* CardinalKit */; };
 		2F49B7782980407C00BCB272 /* FHIR in Frameworks */ = {isa = PBXBuildFile; productRef = 2F49B7772980407C00BCB272 /* FHIR */; };
@@ -67,6 +68,7 @@
 
 /* Begin PBXFileReference section */
 		23B0449A299DB70A008CD957 /* GetUpAndGoTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GetUpAndGoTests.swift; sourceTree = "<group>"; };
+		23DA6D3029ADC1E7007A6B73 /* UtahAppSetup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtahAppSetup.swift; sourceTree = "<group>"; };
 		27A7B3E729A7B2C8000B32B4 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		2F49B77329803E8F00BCB272 /* UtahModules */ = {isa = PBXFileReference; lastKnownFileType = wrapper; path = UtahModules; sourceTree = "<group>"; };
 		2F4E237D2989A2FE0013F3D9 /* OnboardingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingTests.swift; sourceTree = "<group>"; };
@@ -183,6 +185,7 @@
 				2F5E32BC297E05EA003432F8 /* UtahAppDelegate.swift */,
 				2F4E23822989D51F0013F3D9 /* UtahAppTestingSetup.swift */,
 				2FC975A72978F11A00BA99FE /* Home.swift */,
+				23DA6D3029ADC1E7007A6B73 /* UtahAppSetup.swift */,
 				2FC9759D2978E30800BA99FE /* Supporting Files */,
 			);
 			path = Utah;
@@ -406,6 +409,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				23DA6D3129ADC1E7007A6B73 /* UtahAppSetup.swift in Sources */,
 				2FC975A82978F11A00BA99FE /* Home.swift in Sources */,
 				2F4E23832989D51F0013F3D9 /* UtahAppTestingSetup.swift in Sources */,
 				2F5E32BD297E05EA003432F8 /* UtahAppDelegate.swift in Sources */,

--- a/Utah/Utah.swift
+++ b/Utah/Utah.swift
@@ -15,7 +15,7 @@ import UtahSharedContext
 @main
 struct Utah: App {
     @UIApplicationDelegateAdaptor(UtahAppDelegate.self) var appDelegate
-    @AppStorage(StorageKeys.onboardingFlowComplete) var completedOnboardingFlow = false
+    @AppStorage(StorageKeys.onboardingFlowComplete) var completedOnboardingFlow = true
     
     
     var body: some Scene {
@@ -24,6 +24,7 @@ struct Utah: App {
                 .sheet(isPresented: !$completedOnboardingFlow) {
                     OnboardingFlow()
                 }
+                .setup()
                 .testingSetup()
                 .cardinalKit(appDelegate)
         }

--- a/Utah/UtahAppSetup.swift
+++ b/Utah/UtahAppSetup.swift
@@ -1,0 +1,33 @@
+//
+// This source file is part of the CS342 2023 Utah Team Application project
+//
+// SPDX-FileCopyrightText: 2023 Stanford University
+//
+// SPDX-License-Identifier: MIT
+//
+
+import FirebaseAuth
+import SwiftUI
+import UtahSharedContext
+
+
+private struct UtahSetup: ViewModifier {
+    @AppStorage(StorageKeys.onboardingFlowComplete) var completedOnboardingFlow = true
+    
+    
+    func body(content: Content) -> some View {
+        content
+            .task {
+                if Auth.auth().currentUser == nil {
+                    completedOnboardingFlow = false
+                }
+            }
+    }
+}
+
+
+extension View {
+    func setup() -> some View {
+        self.modifier(UtahSetup())
+    }
+}

--- a/UtahModules/Sources/UtahSharedContext/FeatureFlags.swift
+++ b/UtahModules/Sources/UtahSharedContext/FeatureFlags.swift
@@ -6,7 +6,7 @@
 // SPDX-License-Identifier: MIT
 //
 
-/// A collection of feature flags for the PAWS app.
+/// A collection of feature flags for the Utah app.
 public enum FeatureFlags {
     /// Skips the onboarding flow to enable easier development of features in the application and to allow UI tests to skip the onboarding flow.
     public static let skipOnboarding = CommandLine.arguments.contains("--skipOnboarding")


### PR DESCRIPTION
<!--

This source file is part of the Stanford CS342 - Building for Digital Health class

SPDX-FileCopyrightText: 2022 Stanford University

SPDX-License-Identifier: MIT

-->

# *Fix onboarding flow*

## :recycle: Current situation & Problem
when a user was already signed in, the onboarding flow would still show.

## :bulb: Proposed solution
this PR makes it so that if a user is logged in, they will not see the onboarding flow.

## :gear: Release Notes 

## :heavy_plus_sign: Additional Information
Also made tiny change to something small bc I saw it lol

### Related PRs

### Testing
Will adjust in a bit

### Reviewer Nudging

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).

