### PR TITLE
Prevent onboarding flow from being dismissed until complete

### DIFF
--- a/UtahModules/Sources/UtahOnboardingFlow/OnboardingFlow.swift
+++ b/UtahModules/Sources/UtahOnboardingFlow/OnboardingFlow.swift
@@ -23,6 +23,7 @@ public struct OnboardingFlow: View {
     
     
     @SceneStorage(StorageKeys.onboardingFlowStep) private var onboardingSteps: [Step] = []
+    @AppStorage(StorageKeys.onboardingFlowComplete) var completedOnboardingFlow = false
     
     
     public var body: some View {
@@ -46,6 +47,7 @@ public struct OnboardingFlow: View {
                 }
                 .navigationBarTitleDisplayMode(.inline)
         }
+        .interactiveDismissDisabled(!completedOnboardingFlow)
     }
     
     


### PR DESCRIPTION
<!--

This source file is part of the Stanford CS342 - Building for Digital Health class

SPDX-FileCopyrightText: 2022 Stanford University

SPDX-License-Identifier: MIT

-->

# Prevent onboarding flow from being dismissed until complete

## :recycle: Current situation & Problem
The onboarding flow is in a sheet that can be dismissed by dragging it down before the user has completed it.

## :bulb: Proposed solution
Disables dismissing the onboarding flow until it is complete.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).

