### PR TITLE
fixed onboarding test

### DIFF
--- a/UtahUITests/OnboardingTests.swift
+++ b/UtahUITests/OnboardingTests.swift
@@ -118,8 +118,8 @@ extension XCUIApplication {
         XCTAssertTrue(staticTexts["What is your diagnosis?"].waitForExistence(timeout: 2))
         XCTAssertTrue(staticTexts["Choose Diagnosis"].waitForExistence(timeout: 2))
         staticTexts["Choose Diagnosis"].tap()
-        XCTAssertTrue(staticTexts["Arterial Disease"].waitForExistence(timeout: 2))
-        staticTexts["Arterial Disease"].tap()
+        XCTAssertTrue(buttons["Arterial Disease"].waitForExistence(timeout: 2))
+        buttons["Arterial Disease"].tap()
         XCTAssertTrue(buttons["Next"].waitForExistence(timeout: 2))
         buttons["Next"].tap()
     }

--- a/UtahUITests/OnboardingTests.swift
+++ b/UtahUITests/OnboardingTests.swift
@@ -31,10 +31,10 @@ class OnboardingTests: XCTestCase {
         let app = XCUIApplication()
         try app.navigateOnboardingFlow(assertThatHealthKitConsentIsShown: true)
         
-        /*let tabBar = app.tabBars["Tab Bar"]
+        let tabBar = app.tabBars["Tab Bar"]
         XCTAssertTrue(tabBar.buttons["Questions"].waitForExistence(timeout: 2))
         XCTAssertTrue(tabBar.buttons["Trends"].waitForExistence(timeout: 2))
-        XCTAssertTrue(tabBar.buttons["Profile"].waitForExistence(timeout: 2))*/
+        XCTAssertTrue(tabBar.buttons["Profile"].waitForExistence(timeout: 2))
     }
 }
 
@@ -51,10 +51,9 @@ extension XCUIApplication {
         try navigateOnboardingAccount()
         if staticTexts["Consent Form"].waitForExistence(timeout: 5) {
             try navigateOnboardingFlowConsent()
-            // try navigateOnboardingConditionQuestion()
+            try navigateOnboardingConditionQuestion()
         }
-        // must comment out bc I can't figure out how to test the condition picker
-        // try navigateOnboardingFlowHealthKitAccess(assertThatHealthKitConsentIsShown: assertThatHealthKitConsentIsShown)
+        try navigateOnboardingFlowHealthKitAccess(assertThatHealthKitConsentIsShown: assertThatHealthKitConsentIsShown)
     }
     
     private func navigateOnboardingFlowWelcome() throws {


### PR DESCRIPTION
<!--

This source file is part of the Stanford CS342 - Building for Digital Health class

SPDX-FileCopyrightText: 2022 Stanford University

SPDX-License-Identifier: MIT

-->

# Fixed Onboarding Test

## :recycle: Current situation & Problem
The Onboarding test was skipping over the condition question and the healthkit access. This caused issues with testing data collection, because the test user wouldn't grant access to the health app. 

## :bulb: Proposed solution
The condition menu items are buttons, not text. I updated the test to reflect this. 

## :gear: Release Notes 
N/A

## :heavy_plus_sign: Additional Information
N/A

### Related PRs
N/A
### Testing
`On
### Reviewer Nudging
*Where should the reviewer start? Where is a good entry point?*

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).

