### PR TITLE
Add survey timestamps to Firebase

### DIFF
--- a/UtahModules/Sources/UtahSchedule/Edmonton/EdmontonViewCoordinator.swift
+++ b/UtahModules/Sources/UtahSchedule/Edmonton/EdmontonViewCoordinator.swift
@@ -94,7 +94,7 @@ class EdmontonViewCoordinator: NSObject, ORKTaskViewControllerDelegate {
 
         
                 // Upload Score + Data to user collection
-                let userQuestionnaireData = ["score": score, "type": "edmonton", "surveyId": identifier] as [String: Any]
+                let userQuestionnaireData = ["score": score, "type": "edmonton", "surveyId": identifier, "dateCompleted": Timestamp()] as [String: Any]
                 let userUID = user?.uid
                 if userUID != nil {
                     database.collection("users").document(userUID!).collection("QuestionnaireResponse").document(identifier).setData(userQuestionnaireData) { err in

--- a/UtahModules/Sources/UtahSchedule/VEINES/VEINESViewCoordinator.swift
+++ b/UtahModules/Sources/UtahSchedule/VEINES/VEINESViewCoordinator.swift
@@ -83,7 +83,7 @@ class VEINESViewCoordinator: NSObject, ORKTaskViewControllerDelegate {
                 }
                 
                 // Upload Score + Data to user collection
-                let userQuestionnaireData = ["score": score, "type": "veines", "surveyId": identifier] as [String: Any]
+                let userQuestionnaireData = ["score": score, "type": "veines", "surveyId": identifier, "dateCompleted": Timestamp()] as [String: Any]
                 let userUID = user?.uid
                 if userUID != nil {
                     database.collection("users").document(userUID!).collection("QuestionnaireResponse").document(identifier).setData(userQuestionnaireData) { err in

--- a/UtahModules/Sources/UtahSchedule/WIQ/WIQViewCoordinator.swift
+++ b/UtahModules/Sources/UtahSchedule/WIQ/WIQViewCoordinator.swift
@@ -83,7 +83,7 @@ class WIQViewCoordinator: NSObject, ORKTaskViewControllerDelegate {
                 }
                 
                 // Upload Score + Data to user collection
-                let userQuestionnaireData = ["score": score, "type": "wiq", "surveyId": identifier] as [String: Any]
+                let userQuestionnaireData = ["score": score, "type": "wiq", "surveyId": identifier, "dateCompleted": Timestamp()] as [String: Any]
                 let userUID = user?.uid
                 if userUID != nil {
                     database.collection("users").document(userUID!).collection("QuestionnaireResponse").document(identifier).setData(userQuestionnaireData) { err in


### PR DESCRIPTION
<!--

This source file is part of the Stanford CS342 - Building for Digital Health class

SPDX-FileCopyrightText: 2022 Stanford University

SPDX-License-Identifier: MIT

-->

# *Add survey timestamps to Firebase*

## :recycle: Current situation & Problem
We don't store the timestamp of when the last survey was taken. Need it for the trends page.

## :bulb: Proposed solution
Store the timestamp.

## :gear: Release Notes 

## :heavy_plus_sign: Additional Information
It is under the 'dateCompleted' field.

### Related PRs


### Reviewer Nudging

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).

