### PR TITLE
fixed onboarding test to recognize alert

### DIFF
--- a/UtahUITests/OnboardingTests.swift
+++ b/UtahUITests/OnboardingTests.swift
@@ -30,7 +30,11 @@ class OnboardingTests: XCTestCase {
     func testOnboardingFlow() throws {
         let app = XCUIApplication()
         try app.navigateOnboardingFlow(assertThatHealthKitConsentIsShown: true)
-        
+        addUIInterruptionMonitor(withDescription: "System Dialog") {alert -> Bool in
+            alert.buttons["Allow"].tap()
+            return true
+        }
+        app.tap()
         let tabBar = app.tabBars["Tab Bar"]
         XCTAssertTrue(tabBar.buttons["Questions"].waitForExistence(timeout: 2))
         XCTAssertTrue(tabBar.buttons["Trends"].waitForExistence(timeout: 2))
@@ -54,6 +58,7 @@ extension XCUIApplication {
             try navigateOnboardingConditionQuestion()
         }
         try navigateOnboardingFlowHealthKitAccess(assertThatHealthKitConsentIsShown: assertThatHealthKitConsentIsShown)
+        try navigateScheduling()
     }
     
     private func navigateOnboardingFlowWelcome() throws {
@@ -129,5 +134,11 @@ extension XCUIApplication {
         buttons["Grant Access"].tap()
         
         try handleHealthKitAuthorization()
+    }
+    
+    private func navigateScheduling() {
+        XCTAssertTrue(images["heart.text.square.fill"].waitForExistence(timeout: 2))
+        XCTAssertTrue(buttons["Continue"].waitForExistence(timeout: 2))
+        buttons["Continue"].tap()
     }
 }


### PR DESCRIPTION
<!--

This source file is part of the Stanford CS342 - Building for Digital Health class

SPDX-FileCopyrightText: 2022 Stanford University

SPDX-License-Identifier: MIT

-->

# Fixed Onboarding Test

## :recycle: Current situation & Problem
The current Onboarding UI test isn't updated to reflect the scheduler view, which triggers an alert. In the testing suite, the onboarding flow is never technically complete, and this leads to downstream issues such as observations never being uploaded to the emulator.

## :bulb: Proposed solution
I added a function that test the scheduler view, including the alert.

## :gear: Release Notes 
N/A

## :heavy_plus_sign: Additional Information
N/A

### Related PRs
N/A

### Testing
`OnboardingTests`

### Reviewer Nudging
N/A

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).

