### PR TITLE
modified querySurvey function, added survey list to trends page

### DIFF
--- a/UtahModules/Sources/UtahSharedContext/SourceFirestoreManager.swift
+++ b/UtahModules/Sources/UtahSharedContext/SourceFirestoreManager.swift
@@ -10,23 +10,24 @@
 // swiftlint:disable type_contents_order
 // swiftlint:disable legacy_objc_type
 // swiftlint:disable force_unwrapping
+// swiftlint:disable large_tuple
 
 import Account
 import Firebase
 import FirebaseAuth
-import Foundation
 import FirebaseCore
 import FirebaseFirestore
-import SwiftUI
 import FirebaseFirestoreSwift
+import Foundation
+import SwiftUI
 
 public class FirestoreManager: ObservableObject {
     private var db = Firestore.firestore()
     let user = Auth.auth().currentUser
     @Published public var disease: String = ""
     @Published public var observations: [(date: Date, value: Double)] = []
-    @Published public var surveys = [:] as [String : [(dateCompleted: Date, score: Int, surveyId: String)]]
-    //@Published public var surveys: [QuestionnaireResponse] = []
+    @Published public var surveys = [:] as [String: [(dateCompleted: Date, score: Int, surveyId: String)]]
+    // @Published public var surveys: [QuestionnaireResponse] = []
     
     var refresh = false
 
@@ -54,7 +55,7 @@ public class FirestoreManager: ObservableObject {
     public func loadSurveys() async {
         await withCheckedContinuation { continuation in
             if let user = Auth.auth().currentUser {
-                Firestore.firestore().collection("users/\(user.uid)/QuestionnaireResponse").getDocuments{ documents, err in
+                Firestore.firestore().collection("users/\(user.uid)/QuestionnaireResponse").getDocuments { documents, err in
                     if err != nil {
                         return
                     } else {

--- a/UtahModules/Sources/UtahSharedContext/SourceFirestoreManager.swift
+++ b/UtahModules/Sources/UtahSharedContext/SourceFirestoreManager.swift
@@ -15,12 +15,19 @@ import Account
 import Firebase
 import FirebaseAuth
 import Foundation
+import FirebaseCore
+import FirebaseFirestore
+import SwiftUI
+import FirebaseFirestoreSwift
 
 public class FirestoreManager: ObservableObject {
     private var db = Firestore.firestore()
     let user = Auth.auth().currentUser
     @Published public var disease: String = ""
     @Published public var observations: [(date: Date, value: Double)] = []
+    @Published public var surveys = [:] as [String : [(dateCompleted: Date, score: Int, surveyId: String)]]
+    //@Published public var surveys: [QuestionnaireResponse] = []
+    
     var refresh = false
 
     public func update() {
@@ -38,14 +45,77 @@ public class FirestoreManager: ObservableObject {
                     let data = document.data()
                     if let data = data {
                         self.disease = data["disease"] as? String ?? ""
-                        let defaults = UserDefaults.standard
-                        defaults.set(self.disease, forKey: "disease")
                     }
                 }
             }
        }
     }
     
+    public func loadSurveys() async {
+        await withCheckedContinuation { continuation in
+            if let user = Auth.auth().currentUser {
+                Firestore.firestore().collection("users/\(user.uid)/QuestionnaireResponse").getDocuments{ documents, err in
+                    if err != nil {
+                        return
+                    } else {
+                        self.surveys = [:]
+                        for document in documents!.documents {
+                            let data = document.data() as [String: Any]
+                            print(data)
+                            guard let score = data["score"] as? Int else {
+                                print("ERROR: score values nil")
+                                continue
+                            }
+                            guard let surveyId = data["surveyId"] as? String else {
+                                print("ERROR: surveyId values nil")
+                                continue
+                            }
+                            guard let type = data["type"] as? String else {
+                                print("ERROR: type values nil")
+                                continue
+                            }
+                            guard let dateCompletedObject = data["dateCompleted"] as? Timestamp else {
+                                print("ERROR: dateCompleted values nil")
+                                continue
+                            }
+                            let dateCompleted = dateCompletedObject.dateValue()
+                            if self.surveys[type] == nil {
+                                self.surveys[type] = []
+                            }
+                            self.surveys[type]?.append((dateCompleted, score, surveyId))
+                        }
+                        continuation.resume()
+                    }
+                }
+            }
+        }
+    }
+    
+//    func querySurveys(type: String, surveyId: String) async {
+//        await withCheckedContinuation { continuation in
+//            FirebaseApp.configure()
+//            let db = Firestore.firestore()
+//
+//            var surveyName = "veinesssurveys"
+//            if type == "edmonton" {
+//                surveyName = "edmontonsurveys"
+//            } else if type == "wiq" {
+//                surveyName = "wiqsurveys"
+//            }
+//            let docRef = db.collection(surveyName).document(surveyId)
+//            docRef.getDocument(as: QuestionnaireResponse.self) { result in
+//                switch result {
+//                case .success(let response):
+//                    print(response)
+//                    //self.surveys.append(response)
+//                case .failure(let error):
+//                    print(error)
+//                }
+//            }
+//        }
+//    }
+    
+        
     public func loadObservations(metricCode: String) async {
         await withCheckedContinuation { continuation in
             var observations = [] as [(date: Date, value: Double)]
@@ -93,7 +163,8 @@ public class FirestoreManager: ObservableObject {
     
     public init() {
         fetchData()
-        Task {
+        _Concurrency.Task {
+            await loadSurveys()
             await loadObservations(metricCode: "55423-8")
         }
     }

--- a/UtahModules/Sources/UtahTrends/DQRowView.swift
+++ b/UtahModules/Sources/UtahTrends/DQRowView.swift
@@ -1,8 +1,9 @@
 //
-//  SwiftUIView.swift
+// This source file is part of the CS342 2023 Utah Team Application project
 //
+// SPDX-FileCopyrightText: 2023 Stanford University
 //
-//  Created by Audrey Lin on 3/6/23.
+// SPDX-License-Identifier: MIT
 //
 import Account
 import Firebase

--- a/UtahModules/Sources/UtahTrends/DQRowView.swift
+++ b/UtahModules/Sources/UtahTrends/DQRowView.swift
@@ -1,0 +1,46 @@
+//
+//  SwiftUIView.swift
+//
+//
+//  Created by Audrey Lin on 3/6/23.
+//
+import Account
+import Firebase
+import FirebaseAuth
+import FHIR
+import Foundation
+import FirebaseCore
+import FirebaseFirestore
+import SwiftUI
+import FirebaseFirestoreSwift
+import UtahSharedContext
+
+struct DQRowView: View {
+    // questions and answers in same array
+    
+    // turn this into dictionary: q1:"Drawing Clock Test"
+    @EnvironmentObject var firestoreManager: FirestoreManager
+    var questionList = ["q1":"Drawing Clock Test",
+                        "q2":"Times admitted to a hospital the past year",
+                        "q3":"Description of overall health"]
+    var surveyType : String
+    @State var answerList = [QuestionList]()
+    let questionnaireResponse : QuestionnaireResponse
+    var body: some View {
+        ScrollView {
+            ForEach(answerList, id:\.self) { item in
+                Text(item.questionDescription)
+                    .padding(.all, 10)
+                    .background(Rectangle().fill(Color.accentColor).shadow(radius: 3)
+                        .cornerRadius(15)
+                    )
+                    .foregroundColor(.white)
+                
+                Spacer()
+                Text(item.answer)
+            }
+            .font(.title)
+            // call fn that returns this answer list - calls out to firebase, grabs all answers and returns tis list
+        }.onAppear(perform: {answerList = [QuestionList(questionID: "q1", questionDescription: questionList["q1"] ?? "", answer: "yes"), QuestionList(questionID: "q2", questionDescription: questionList["q2"] ?? "", answer: "yes"), QuestionList(questionID: "q3", questionDescription: questionList["q3"] ?? "", answer: "yes")]})
+    }
+}

--- a/UtahModules/Sources/UtahTrends/DQRowView.swift
+++ b/UtahModules/Sources/UtahTrends/DQRowView.swift
@@ -6,14 +6,14 @@
 // SPDX-License-Identifier: MIT
 //
 import Account
+import FHIR
 import Firebase
 import FirebaseAuth
-import FHIR
-import Foundation
 import FirebaseCore
 import FirebaseFirestore
-import SwiftUI
 import FirebaseFirestoreSwift
+import Foundation
+import SwiftUI
 import UtahSharedContext
 
 struct DQRowView: View {
@@ -21,12 +21,12 @@ struct DQRowView: View {
     
     // turn this into dictionary: q1:"Drawing Clock Test"
     @EnvironmentObject var firestoreManager: FirestoreManager
-    var questionList = ["q1":"Drawing Clock Test",
-                        "q2":"Times admitted to a hospital the past year",
-                        "q3":"Description of overall health"]
-    let surveyType : String
-    let score : Int
-    var answerList : [QuestionListItem] {
+    var questionList = ["q1": "Drawing Clock Test",
+                        "q2": "Times admitted to a hospital the past year",
+                        "q3": "Description of overall health"]
+    let surveyType: String
+    let score: Int
+    var answerList: [QuestionListItem] {
         switch surveyType {
         case "veinesssurveys":
             return veinesQList()
@@ -38,13 +38,15 @@ struct DQRowView: View {
             return []
         }
     }
-    let questionnaireResponse : QuestionnaireResponse
+    let questionnaireResponse: QuestionnaireResponse
     var body: some View {
         ScrollView {
-            ForEach(answerList, id:\.self) { item in
+            ForEach(answerList, id: \.self) { item in
                 Text(item.questionDescription)
                     .padding(.all, 10)
-                    .background(Rectangle().fill(Color.accentColor).shadow(radius: 3)
+                    .background(Rectangle()
+                        .fill(Color.accentColor)
+                        .shadow(radius: 3)
                         .cornerRadius(15)
                     )
                     .foregroundColor(.white)
@@ -56,13 +58,12 @@ struct DQRowView: View {
             // call fn that returns this answer list - calls out to firebase, grabs all answers and returns tis list
         }
     }
-    func edmontonQList() -> [QuestionListItem]{
-        var edmontonList : [QuestionListItem] = []
-        var answer : String
+    func edmontonQList() -> [QuestionListItem] {
+        var edmontonList: [QuestionListItem] = []
+        var answer: String
         if questionnaireResponse.item?[0].answer?.rawValue == nil {
             answer = "Not uploaded"
-        }
-        else {
+        } else {
             answer = "Uploaded successfully"
         }
         let firstQuestion = QuestionListItem(questionDescription: "Clock Test", answer: answer)
@@ -70,11 +71,11 @@ struct DQRowView: View {
         return edmontonList
     }
     
-    func wiqQList() -> [QuestionListItem]{
-        return []
+    func wiqQList() -> [QuestionListItem] {
+        []
     }
     
-    func veinesQList() -> [QuestionListItem]{
-        return []
+    func veinesQList() -> [QuestionListItem] {
+        []
     }
 }

--- a/UtahModules/Sources/UtahTrends/DQRowView.swift
+++ b/UtahModules/Sources/UtahTrends/DQRowView.swift
@@ -24,8 +24,20 @@ struct DQRowView: View {
     var questionList = ["q1":"Drawing Clock Test",
                         "q2":"Times admitted to a hospital the past year",
                         "q3":"Description of overall health"]
-    var surveyType : String
-    @State var answerList = [QuestionList]()
+    let surveyType : String
+    let score : Int
+    var answerList : [QuestionListItem] {
+        switch surveyType {
+        case "veinesssurveys":
+            return veinesQList()
+        case "edmonton":
+            return edmontonQList()
+        case "wiq":
+            return wiqQList()
+        default:
+            return []
+        }
+    }
     let questionnaireResponse : QuestionnaireResponse
     var body: some View {
         ScrollView {
@@ -42,6 +54,27 @@ struct DQRowView: View {
             }
             .font(.title)
             // call fn that returns this answer list - calls out to firebase, grabs all answers and returns tis list
-        }.onAppear(perform: {answerList = [QuestionList(questionID: "q1", questionDescription: questionList["q1"] ?? "", answer: "yes"), QuestionList(questionID: "q2", questionDescription: questionList["q2"] ?? "", answer: "yes"), QuestionList(questionID: "q3", questionDescription: questionList["q3"] ?? "", answer: "yes")]})
+        }
+    }
+    func edmontonQList() -> [QuestionListItem]{
+        var edmontonList : [QuestionListItem] = []
+        var answer : String
+        if questionnaireResponse.item?[0].answer?.rawValue == nil {
+            answer = "Not uploaded"
+        }
+        else {
+            answer = "Uploaded successfully"
+        }
+        let firstQuestion = QuestionListItem(questionDescription: "Clock Test", answer: answer)
+        edmontonList.append(firstQuestion)
+        return edmontonList
+    }
+    
+    func wiqQList() -> [QuestionListItem]{
+        return []
+    }
+    
+    func veinesQList() -> [QuestionListItem]{
+        return []
     }
 }

--- a/UtahModules/Sources/UtahTrends/DetailedQuestionnaireView.swift
+++ b/UtahModules/Sources/UtahTrends/DetailedQuestionnaireView.swift
@@ -1,8 +1,9 @@
 //
-//  SwiftUIView.swift
+// This source file is part of the CS342 2023 Utah Team Application project
 //
+// SPDX-FileCopyrightText: 2023 Stanford University
 //
-//  Created by Audrey Lin on 3/5/23.
+// SPDX-License-Identifier: MIT
 //
 import Account
 import Firebase

--- a/UtahModules/Sources/UtahTrends/DetailedQuestionnaireView.swift
+++ b/UtahModules/Sources/UtahTrends/DetailedQuestionnaireView.swift
@@ -6,14 +6,14 @@
 // SPDX-License-Identifier: MIT
 //
 import Account
+import FHIR
 import Firebase
 import FirebaseAuth
-import FHIR
-import Foundation
 import FirebaseCore
 import FirebaseFirestore
-import SwiftUI
 import FirebaseFirestoreSwift
+import Foundation
+import SwiftUI
 import UtahSharedContext
 
 struct DetailedQuestionnaireView: View {
@@ -30,8 +30,7 @@ struct DetailedQuestionnaireView: View {
                 DQRowView(surveyType: type, score: score, questionnaireResponse: survey)
                     .navigationBarTitle("Previous Response")
                     .navigationTitle("[date], [type of survey]")
-            }
-            else {
+            } else {
                 ProgressView()
             }
         }
@@ -41,7 +40,7 @@ struct DetailedQuestionnaireView: View {
     }
         
     
-        public func querySurveys(type: String, surveyId: String) async -> QuestionnaireResponse? {
+        func querySurveys(type: String, surveyId: String) async -> QuestionnaireResponse? {
             await withCheckedContinuation { continuation in
                 let db = Firestore.firestore()
                 var surveyName = "veinesssurveys"

--- a/UtahModules/Sources/UtahTrends/DetailedQuestionnaireView.swift
+++ b/UtahModules/Sources/UtahTrends/DetailedQuestionnaireView.swift
@@ -21,12 +21,13 @@ struct DetailedQuestionnaireView: View {
     @State var survey: QuestionnaireResponse?
     var surveyId: String
     var type: String
+    var score: Int
     
     var body: some View {
         NavigationStack {
             Spacer()
             if let survey {
-                DQRowView(surveyType: type, questionnaireResponse: survey)
+                DQRowView(surveyType: type, score: score, questionnaireResponse: survey)
                     .navigationBarTitle("Previous Response")
                     .navigationTitle("[date], [type of survey]")
             }
@@ -66,6 +67,6 @@ struct DetailedQuestionnaireView: View {
 
 struct DetailedQuestionnaireView_Previews: PreviewProvider {
     static var previews: some View {
-        DetailedQuestionnaireView(surveyId: "", type: "")
+        DetailedQuestionnaireView(surveyId: "", type: "", score: 0)
     }
 }

--- a/UtahModules/Sources/UtahTrends/QuestionList.swift
+++ b/UtahModules/Sources/UtahTrends/QuestionList.swift
@@ -1,8 +1,9 @@
 //
-//  File.swift
+// This source file is part of the CS342 2023 Utah Team Application project
 //
+// SPDX-FileCopyrightText: 2023 Stanford University
 //
-//  Created by Audrey Lin on 3/7/23.
+// SPDX-License-Identifier: MIT
 //
 import Foundation
 

--- a/UtahModules/Sources/UtahTrends/QuestionList.swift
+++ b/UtahModules/Sources/UtahTrends/QuestionList.swift
@@ -1,0 +1,13 @@
+//
+//  File.swift
+//
+//
+//  Created by Audrey Lin on 3/7/23.
+//
+import Foundation
+
+struct QuestionList: Hashable, Codable {
+    var questionID: String
+    var questionDescription: String
+    var answer: String
+}

--- a/UtahModules/Sources/UtahTrends/QuestionListItem.swift
+++ b/UtahModules/Sources/UtahTrends/QuestionListItem.swift
@@ -7,8 +7,7 @@
 //
 import Foundation
 
-struct QuestionList: Hashable, Codable {
-    var questionID: String
+struct QuestionListItem: Hashable, Codable {
     var questionDescription: String
     var answer: String
 }

--- a/UtahModules/Sources/UtahTrends/SurveyHistoryList.swift
+++ b/UtahModules/Sources/UtahTrends/SurveyHistoryList.swift
@@ -5,9 +5,9 @@
 //
 // SPDX-License-Identifier: MIT
 //
+import FHIR
 import Foundation
 import SwiftUI
-import FHIR
 import UtahSharedContext
 
 struct SurveyHistoryList: View {
@@ -18,7 +18,7 @@ struct SurveyHistoryList: View {
     var body: some View {
         NavigationView {
             List {
-                ForEach (Array(firestoreManager.surveys.keys), id:\.self) { surveySection in
+                ForEach(Array(firestoreManager.surveys.keys), id: \.self) { surveySection in
                     Section(surveySection, content: {
                         createSurveySection(surveySection: surveySection)
                     })
@@ -30,7 +30,7 @@ struct SurveyHistoryList: View {
         }
     }
     func createSurveySection(surveySection: String) -> some View {
-        ForEach (firestoreManager.surveys[surveySection] ?? [], id:\.surveyId) { survey in
+        ForEach(firestoreManager.surveys[surveySection] ?? [], id: \.surveyId) { survey in
             NavigationLink {
                 DetailedQuestionnaireView(surveyId: survey.surveyId, type: surveySection, score: survey.score)
             } label: {
@@ -39,4 +39,3 @@ struct SurveyHistoryList: View {
         }
     }
 }
-

--- a/UtahModules/Sources/UtahTrends/SurveyHistoryList.swift
+++ b/UtahModules/Sources/UtahTrends/SurveyHistoryList.swift
@@ -1,0 +1,41 @@
+//
+//  File.swift
+//
+//
+//  Created by Emmy Thamakaison on 5/3/2566 BE.
+//
+import Foundation
+import SwiftUI
+import FHIR
+import UtahSharedContext
+
+struct SurveyHistoryList: View {
+    @EnvironmentObject var firestoreManager: FirestoreManager
+    @State var surveys: [QuestionnaireResponse] = []
+    
+    
+    var body: some View {
+        NavigationView {
+            List {
+                ForEach (Array(firestoreManager.surveys.keys), id:\.self) { surveySection in
+                    Section(surveySection, content: {
+                        createSurveySection(surveySection: surveySection)
+                    })
+                }
+            }
+            .task {
+                await firestoreManager.loadSurveys()
+            }
+        }
+    }
+    func createSurveySection(surveySection: String) -> some View {
+        ForEach (firestoreManager.surveys[surveySection] ?? [], id:\.surveyId) { survey in
+            NavigationLink {
+                DetailedQuestionnaireView(surveyId: survey.surveyId, type: surveySection)
+            } label: {
+                SurveyRow(dateCompleted: survey.dateCompleted)
+            }
+        }
+    }
+}
+

--- a/UtahModules/Sources/UtahTrends/SurveyHistoryList.swift
+++ b/UtahModules/Sources/UtahTrends/SurveyHistoryList.swift
@@ -1,8 +1,9 @@
 //
-//  File.swift
+// This source file is part of the CS342 2023 Utah Team Application project
 //
+// SPDX-FileCopyrightText: 2023 Stanford University
 //
-//  Created by Emmy Thamakaison on 5/3/2566 BE.
+// SPDX-License-Identifier: MIT
 //
 import Foundation
 import SwiftUI

--- a/UtahModules/Sources/UtahTrends/SurveyHistoryList.swift
+++ b/UtahModules/Sources/UtahTrends/SurveyHistoryList.swift
@@ -32,7 +32,7 @@ struct SurveyHistoryList: View {
     func createSurveySection(surveySection: String) -> some View {
         ForEach (firestoreManager.surveys[surveySection] ?? [], id:\.surveyId) { survey in
             NavigationLink {
-                DetailedQuestionnaireView(surveyId: survey.surveyId, type: surveySection)
+                DetailedQuestionnaireView(surveyId: survey.surveyId, type: surveySection, score: survey.score)
             } label: {
                 SurveyRow(dateCompleted: survey.dateCompleted)
             }

--- a/UtahModules/Sources/UtahTrends/SurveyRow.swift
+++ b/UtahModules/Sources/UtahTrends/SurveyRow.swift
@@ -5,9 +5,9 @@
 //
 // SPDX-License-Identifier: MIT
 //
+import FHIR
 import Foundation
 import SwiftUI
-import FHIR
 
 struct SurveyRow: View {
     var dateCompleted: Date
@@ -18,8 +18,8 @@ struct SurveyRow: View {
     }
 }
 
-//struct SurveyRow_Previews: PreviewProvider {
+// struct SurveyRow_Previews: PreviewProvider {
 //    static var previews: some View {
 //        SurveyRow(surveyHistory: surveyHistory[0])
 //    }
-//}
+// }

--- a/UtahModules/Sources/UtahTrends/SurveyRow.swift
+++ b/UtahModules/Sources/UtahTrends/SurveyRow.swift
@@ -1,0 +1,24 @@
+//
+//  File.swift
+//
+//
+//  Created by Emmy Thamakaison on 5/3/2566 BE.
+//
+import Foundation
+import SwiftUI
+import FHIR
+
+struct SurveyRow: View {
+    var dateCompleted: Date
+    let dateFormatter = DateFormatter()
+    
+    var body: some View {
+        Text(dateCompleted, format: .dateTime)
+    }
+}
+
+//struct SurveyRow_Previews: PreviewProvider {
+//    static var previews: some View {
+//        SurveyRow(surveyHistory: surveyHistory[0])
+//    }
+//}

--- a/UtahModules/Sources/UtahTrends/SurveyRow.swift
+++ b/UtahModules/Sources/UtahTrends/SurveyRow.swift
@@ -1,8 +1,9 @@
 //
-//  File.swift
+// This source file is part of the CS342 2023 Utah Team Application project
 //
+// SPDX-FileCopyrightText: 2023 Stanford University
 //
-//  Created by Emmy Thamakaison on 5/3/2566 BE.
+// SPDX-License-Identifier: MIT
 //
 import Foundation
 import SwiftUI

--- a/UtahModules/Sources/UtahTrends/Trends.swift
+++ b/UtahModules/Sources/UtahTrends/Trends.swift
@@ -19,19 +19,23 @@ import UtahSharedContext
      
     public var body: some View {
         NavigationStack {
-            VStack(alignment: .center, spacing: 10) {
-                Charts()
-                    .frame(minHeight: 250)
-                Spacer()
-                DataCard(
-                    icon: "shoeprints.fill",
-                    title: "Daily Step Count",
-                    unit: "steps",
-                    color: Color.green
-                )
-                Spacer()
-                // removed survey for now until we pull survey data from firestore
-                // DataCard(icon: "list.clipboard.fill", title: "Last EFS Survey Score", unit: "points", color: Color.blue, observations: [])
+            ScrollView {
+                VStack(alignment: .center, spacing: 10) {
+                    Charts()
+                        .frame(minHeight: 250)
+                    Spacer()
+                    DataCard(
+                        icon: "shoeprints.fill",
+                        title: "Daily Step Count",
+                        unit: "steps",
+                        color: Color.green
+                    )
+                    Spacer()
+                    // removed survey for now until we pull survey data from firestore
+                    // DataCard(icon: "list.clipboard.fill", title: "Last EFS Survey Score", unit: "points", color: Color.blue, observations: [])
+                    Spacer()
+                    SurveyHistoryList()
+                }
             }
         }
         .padding()


### PR DESCRIPTION
<!--

This source file is part of the Stanford CS342 - Building for Digital Health class

SPDX-FileCopyrightText: 2022 Stanford University

SPDX-License-Identifier: MIT

-->

# *Questionnaire History Page*

## :recycle: Current situation & Problem
We currently lack a way for users to look at their previous Questionnaire responses.

## :bulb: Proposed solution
We made a Questionnaire History view. We also implemented functionality to pull survey scores and survey responses.

## :gear: Release Notes 
N/A

## :heavy_plus_sign: Additional Information
N/A

### Related PRs
N/A

### Testing
We didn't add any tests currently. This is because the UI is not complete yet, and will be independent from the Trends Page.

### Reviewer Nudging
*Where should the reviewer start? Where is a good entry point?*

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [ X] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).

