### PR TITLE
added Veines Survey

### DIFF
--- a/UtahModules/Sources/UtahTrends/SurveyChartView.swift
+++ b/UtahModules/Sources/UtahTrends/SurveyChartView.swift
@@ -27,18 +27,19 @@ let efsDummyData: [EFS] = [
     .init(date: "May", score: 9)
 ]
 
-struct EdmontonChart: View {
+struct SurveyChart: View {
+    let title: String
     var body: some View {
         VStack(alignment: .leading) {
             VStack(alignment: .center) {
-                Text("Edmonton Frail Scale")
+                Text(title)
                     .font(.headline)
                     .padding(.top)
                 Chart {
                     ForEach(efsDummyData) { datum in
                         BarMark(
                             x: .value("Date", datum.date),
-                            y: .value("Edmonton Frail Scale Score", datum.score)
+                            y: .value("\(title) Score", datum.score)
                         )
                     }
                 }
@@ -55,6 +56,6 @@ struct EdmontonChart: View {
 
 struct EdmontonChart_Previews: PreviewProvider {
     static var previews: some View {
-        EdmontonChart()
+        SurveyChart(title: "Edmonton Frail Scale")
     }
 }

--- a/UtahModules/Sources/UtahTrends/Trends.swift
+++ b/UtahModules/Sources/UtahTrends/Trends.swift
@@ -23,6 +23,7 @@ public struct Trends: View {
     @EnvironmentObject var firestoreManager: FirestoreManager
     @State private var showStepCount = false
     @State private var showEdmonton = false
+    @State private var showVeines = false
     // we will check whether we have these surveys in the db
     @State private var edmonton_db = false
     @State private var veins_db = false
@@ -44,11 +45,17 @@ public struct Trends: View {
                             self.showEdmonton.toggle()
                         }
                         .sheet(isPresented: $showEdmonton) {
-                            EdmontonChart()
+                            SurveyChart(title: "Edmonton Frail Scale")
                         }
                     } else if survey == "veines" {
                         DataCard(icon: "list.clipboard.fill", title: "Veines Survey Score", unit: "points", color: Color.purple)
                             .padding(.vertical, 10)
+                            .onTapGesture {
+                                self.showVeines.toggle()
+                            }
+                            .sheet(isPresented: $showVeines) {
+                                SurveyChart(title: "Veines Survey")
+                            }
                     }
                 }
                 DataCard(


### PR DESCRIPTION
<!--

This source file is part of the Stanford CS342 - Building for Digital Health class

SPDX-FileCopyrightText: 2022 Stanford University

SPDX-License-Identifier: MIT

-->

# Added Veines Chart

## :recycle: Current situation & Problem
The Veines data card does not have an associated chart. 

## :bulb: Proposed solution
I made the Edmonton Chart view more generalizable to all surveys, and added a Veines chart.

## :gear: Release Notes 

## :heavy_plus_sign: Additional Information
*Provide some additional information if possible*

https://user-images.githubusercontent.com/56773304/225526425-e0829d49-19c7-418d-aa96-1ca1d92aa93f.mp4


### Related PRs

### Testing

### Reviewer Nudging
*Where should the reviewer start? Where is a good entry point?*

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/CS342/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CS342/.github/blob/main/CONTRIBUTING.md).

